### PR TITLE
MP-2041 - Fix podspec including non source files

### DIFF
--- a/Rokt.Widget/rokt-react-native-sdk.podspec
+++ b/Rokt.Widget/rokt-react-native-sdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/ROKT/rokt-sdk-react-native", :tag => "#{s.version}" }
 
   
-  s.source_files = "ios/**/*.*"
+  s.source_files = "ios/**/*.{h,m}"
   
 
   s.dependency "React"

--- a/RoktSampleApp/ios/Podfile.lock
+++ b/RoktSampleApp/ios/Podfile.lock
@@ -559,7 +559,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 65cd2782a57e1d59a68aa5d504edf94278578e41
   ReactCommon: 1e783348b9aa73ae68236271df972ba898560a95
   RNCCheckbox: 38989bbd3d7d536adf24ba26c6b3e6cefe0bea6f
-  rokt-react-native-sdk: a558000fcf8503ba2003b7623438ed7a42999255
+  rokt-react-native-sdk: c95468fa6c9254752758b36cc210a23c5bcf747f
   Rokt-Widget: 34851c3d484c848edaee2d56068a6f9452b9f941
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 0b84a956f7393ef1f37f3bb213c516184e4a689d


### PR DESCRIPTION
### Background ###

Cherry-pick https://github.com/ROKT/rokt-sdk-react-native/pull/78 and other packaging changes


### What Has Changed: ###

Fixes xcode warning: no rule to process file '/<project_path>/node_modules/@rokt/react-native-sdk/ios/RNRoktWidget.xcodeproj/project.pbxproj' of type 'text.pbxproject' for architecture 'arm64'

### How Has This Been Tested? ###

### Notes

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.