### PR TITLE
add sendUrlFailure

### DIFF
--- a/Rokt.Widget/ios/RNRoktWidget.m
+++ b/Rokt.Widget/ios/RNRoktWidget.m
@@ -147,6 +147,10 @@ RCT_EXPORT_METHOD(setFulfillmentAttributes:(NSDictionary *)attributes) {
         [self.roktEventHandler setFulfillmentAttributesWithAttributes:attributes];
     }
 }
+RCT_EXPORT_METHOD(sendUrlFailure:(NSString *)urlId brokenUrl:(NSString *)brokenUrl description:(NSString *)description)
+{
+    [Rokt sendUrlFailureWithUrlId:urlId brokenUrl:brokenUrl description:description];
+}
 
 - (NSMutableDictionary*)convertAttributesToDictionary:(NSDictionary*)attributes
 {

--- a/Rokt.Widget/src/index.tsx
+++ b/Rokt.Widget/src/index.tsx
@@ -10,6 +10,7 @@ export interface RNRoktWidget {
     setEnvironmentToStage(): void;
     setEnvironmentToProd(): void;
     toggleDebug(enabled: boolean): void;
+    sendUrlFailure(urlId: string, brokenUrl: string, description: string): void;
 }
 
 declare module 'react-native' {


### PR DESCRIPTION
### Background ###

Add ability for RN partner to send URL error reports

### What Has Changed: ###

- Add `sendUrlFailure` method that forwards to iOS SDK sendUrlFailure

### How Has This Been Tested? ###

Tested locally (added error call to sample app and check diagnostics send)

https://github.com/ROKT/rokt-sdk-react-native/assets/122853726/0fb9c6c4-757f-42ad-b70e-d99ebd48f296

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.