### PR TITLE
[NO_JIRA] Disabling BuildConfig generation

### DIFF
--- a/Rokt.Widget/android/build.gradle
+++ b/Rokt.Widget/android/build.gradle
@@ -26,6 +26,9 @@ android {
     lintOptions {
         abortOnError false
     }
+    buildFeatures {
+        buildConfig = false
+    }
 }
 
 repositories {

--- a/Rokt.Widget/package-lock.json
+++ b/Rokt.Widget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rokt/react-native-sdk",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rokt/react-native-sdk",
-      "version": "3.15.1",
+      "version": "3.15.2",
       "license": "Copyright 2020 Rokt Pte Ltd",
       "devDependencies": {
         "@types/jest": "^27.5.1",

--- a/Rokt.Widget/package.json
+++ b/Rokt.Widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rokt/react-native-sdk",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "description": "Rokt Mobile SDK to integrate ROKT Api into ReactNative application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/RoktSampleApp/package.json
+++ b/RoktSampleApp/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@react-native-community/checkbox": "^0.5.12",
-    "@rokt/react-native-sdk": "file:../Rokt.Widget/rokt-react-native-sdk-3.15.1.tgz",
+    "@rokt/react-native-sdk": "file:../Rokt.Widget/rokt-react-native-sdk-3.15.2.tgz",
     "crypto-js": "^4.0.0",
     "node-forge": "^1.3.1",
     "react": "18.0.0",


### PR DESCRIPTION
### Background ###

Disabling generation of BuildConfig since it causes conflicts to due package naming.

Fixes [NO-JIRA]

### What Has Changed: ###

- Disabled generating BuildConfig for Android
- Updated version to 3.15.2

### How Has This Been Tested? ###

- Tested build locally and BuildConfig was not generated for Debug and Release variants
- Build passed with known conflicting package

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.