### PR TITLE
[NO-JIRA] Make android embedded background transparent

### DIFF
--- a/Rokt.Widget/src/rokt-embedded-view.android.tsx
+++ b/Rokt.Widget/src/rokt-embedded-view.android.tsx
@@ -85,7 +85,7 @@ const WidgetNativeComponent: HostComponent<WidgetNativeComponentProps> = require
 const styles = StyleSheet.create({
   widget: {
     flex: 1,
-    backgroundColor: 'white'
+    backgroundColor: 'transparent'
   },
 });
 


### PR DESCRIPTION
### Background ###

Corner radius on Android doesn't display properly because of the background being white instead of transparent.

Fixes [NO-JIRA]

### What Has Changed: ###

Make embedded background transparent instead of white

### How Has This Been Tested? ###

#### Before
![image](https://github.com/ROKT/rokt-sdk-react-native/assets/122851605/2d35af30-f985-4ae2-ac62-e6bba7efaec7)

#### After
![image](https://github.com/ROKT/rokt-sdk-react-native/assets/122851605/5dc4f8e0-3bc6-4279-8b90-c95a419f1088)

### Notes

Same was applied for iOS before

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.