### PR TITLE
[NO-JIRA] Change Map to Record

### DIFF
--- a/Rokt.Widget/src/index.tsx
+++ b/Rokt.Widget/src/index.tsx
@@ -4,8 +4,8 @@ import 'react-native'
 
 export interface RNRoktWidget {
     initialize(roktTagId: string, appVersion: string): void;
-    execute(viewName: string, attributes: Map<string, string>, placeholders: Map<string, number>): void;
-    execute2Step(viewName: string, attributes: Map<string, string>, placeholders: Map<string, number>): void;
+    execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number>): void;
+    execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number>): void;
     setFulfillmentAttributes(attributes: Map<string, string>): void;
     setEnvironmentToStage(): void;
     setEnvironmentToProd(): void;


### PR DESCRIPTION
### Background ###

The `Map` type is not passing attributes correctly to `execute`. It is also too restrictive and requires instantiation via `new Map()` instead of just creating an object. `Record` allows for js style objects like
```
const attributes = {
    "email": "test@test.com"
}
```
and still enforces type safety.

Fixes [NO-JIRA]

### What Has Changed: ###

- Changed `Map` to `Record`

### How Has This Been Tested? ###

Tested in a Typescript file.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.