### PR TITLE
[MP-2722] Correct types

### DIFF
--- a/Rokt.Widget/package.json
+++ b/Rokt.Widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rokt/react-native-sdk",
-  "version": "3.15.5",
+  "version": "3.15.6",
   "description": "Rokt Mobile SDK to integrate ROKT Api into ReactNative application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/Rokt.Widget/src/index.tsx
+++ b/Rokt.Widget/src/index.tsx
@@ -4,8 +4,14 @@ import 'react-native'
 
 export interface RNRoktWidget {
     initialize(roktTagId: string, appVersion: string): void;
-    execute(viewName: string, attributes: Map<string, string> | Record<string, string>, placeholders: Map<string, number> | Record<string, number>, callback: () => void): void;
-    execute2Step(viewName: string, attributes: Map<string, string> | Record<string, string>, placeholders: Map<string, number> | Record<string, number>, callback: () => void): void;
+    execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, callback: () => void): void;
+    /** @deprecated execute with type {@link Map} is depreacted, use signature with {@link Record} instead*/
+    execute(viewName: string, attributes: Map<string, string>, placeholders: Map<string, number>, callback: () => void): void;
+    execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, callback: () => void): void;
+    /** @deprecated execute2Step with type {@link Map} is depreacted, use signature with {@link Record} instead*/
+    execute2Step(viewName: string, attributes: Map<string, string>, placeholders: Map<string, number>, callback: () => void): void;
+    setFulfillmentAttributes(attributes: Record<string, string>): void;
+    /** @deprecated setFulfillmentAttributes with type {@link Map} is depreacted, use signature with {@link Record} instead*/
     setFulfillmentAttributes(attributes: Map<string, string>): void;
     setEnvironmentToStage(): void;
     setEnvironmentToProd(): void;

--- a/RoktSampleApp/ios/Podfile.lock
+++ b/RoktSampleApp/ios/Podfile.lock
@@ -3,14 +3,14 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.69.10)
-  - FBReactNativeSpec (0.69.10):
+  - FBLazyVector (0.69.12)
+  - FBReactNativeSpec (0.69.12):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.10)
-    - RCTTypeSafety (= 0.69.10)
-    - React-Core (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - ReactCommon/turbomodule/core (= 0.69.10)
+    - RCTRequired (= 0.69.12)
+    - RCTTypeSafety (= 0.69.12)
+    - React-Core (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - ReactCommon/turbomodule/core (= 0.69.12)
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -87,277 +87,277 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.69.10)
-  - RCTTypeSafety (0.69.10):
-    - FBLazyVector (= 0.69.10)
-    - RCTRequired (= 0.69.10)
-    - React-Core (= 0.69.10)
-  - React (0.69.10):
-    - React-Core (= 0.69.10)
-    - React-Core/DevSupport (= 0.69.10)
-    - React-Core/RCTWebSocket (= 0.69.10)
-    - React-RCTActionSheet (= 0.69.10)
-    - React-RCTAnimation (= 0.69.10)
-    - React-RCTBlob (= 0.69.10)
-    - React-RCTImage (= 0.69.10)
-    - React-RCTLinking (= 0.69.10)
-    - React-RCTNetwork (= 0.69.10)
-    - React-RCTSettings (= 0.69.10)
-    - React-RCTText (= 0.69.10)
-    - React-RCTVibration (= 0.69.10)
-  - React-bridging (0.69.10):
+  - RCTRequired (0.69.12)
+  - RCTTypeSafety (0.69.12):
+    - FBLazyVector (= 0.69.12)
+    - RCTRequired (= 0.69.12)
+    - React-Core (= 0.69.12)
+  - React (0.69.12):
+    - React-Core (= 0.69.12)
+    - React-Core/DevSupport (= 0.69.12)
+    - React-Core/RCTWebSocket (= 0.69.12)
+    - React-RCTActionSheet (= 0.69.12)
+    - React-RCTAnimation (= 0.69.12)
+    - React-RCTBlob (= 0.69.12)
+    - React-RCTImage (= 0.69.12)
+    - React-RCTLinking (= 0.69.12)
+    - React-RCTNetwork (= 0.69.12)
+    - React-RCTSettings (= 0.69.12)
+    - React-RCTText (= 0.69.12)
+    - React-RCTVibration (= 0.69.12)
+  - React-bridging (0.69.12):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi (= 0.69.10)
-  - React-callinvoker (0.69.10)
-  - React-Codegen (0.69.10):
-    - FBReactNativeSpec (= 0.69.10)
+    - React-jsi (= 0.69.12)
+  - React-callinvoker (0.69.12)
+  - React-Codegen (0.69.12):
+    - FBReactNativeSpec (= 0.69.12)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.10)
-    - RCTTypeSafety (= 0.69.10)
-    - React-Core (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - ReactCommon/turbomodule/core (= 0.69.10)
-  - React-Core (0.69.10):
+    - RCTRequired (= 0.69.12)
+    - RCTTypeSafety (= 0.69.12)
+    - React-Core (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - ReactCommon/turbomodule/core (= 0.69.12)
+  - React-Core (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.10)
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-Core/Default (= 0.69.12)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.69.10):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
-    - Yoga
-  - React-Core/Default (0.69.10):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
-    - Yoga
-  - React-Core/DevSupport (0.69.10):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.10)
-    - React-Core/RCTWebSocket (= 0.69.10)
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-jsinspector (= 0.69.10)
-    - React-perflogger (= 0.69.10)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.69.10):
+  - React-Core/CoreModulesHeaders (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.69.10):
+  - React-Core/Default (0.69.12):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
+    - Yoga
+  - React-Core/DevSupport (0.69.12):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.69.12)
+    - React-Core/RCTWebSocket (= 0.69.12)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-jsinspector (= 0.69.12)
+    - React-perflogger (= 0.69.12)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.69.10):
+  - React-Core/RCTAnimationHeaders (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-Core/RCTImageHeaders (0.69.10):
+  - React-Core/RCTBlobHeaders (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.69.10):
+  - React-Core/RCTImageHeaders (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.69.10):
+  - React-Core/RCTLinkingHeaders (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.69.10):
+  - React-Core/RCTNetworkHeaders (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-Core/RCTTextHeaders (0.69.10):
+  - React-Core/RCTSettingsHeaders (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.69.10):
+  - React-Core/RCTTextHeaders (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-Core/RCTWebSocket (0.69.10):
+  - React-Core/RCTVibrationHeaders (0.69.12):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.10)
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsiexecutor (= 0.69.10)
-    - React-perflogger (= 0.69.10)
+    - React-Core/Default
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
     - Yoga
-  - React-CoreModules (0.69.10):
+  - React-Core/RCTWebSocket (0.69.12):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.10)
-    - React-Codegen (= 0.69.10)
-    - React-Core/CoreModulesHeaders (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-RCTImage (= 0.69.10)
-    - ReactCommon/turbomodule/core (= 0.69.10)
-  - React-cxxreact (0.69.10):
+    - React-Core/Default (= 0.69.12)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsiexecutor (= 0.69.12)
+    - React-perflogger (= 0.69.12)
+    - Yoga
+  - React-CoreModules (0.69.12):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.69.12)
+    - React-Codegen (= 0.69.12)
+    - React-Core/CoreModulesHeaders (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-RCTImage (= 0.69.12)
+    - ReactCommon/turbomodule/core (= 0.69.12)
+  - React-cxxreact (0.69.12):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-jsinspector (= 0.69.10)
-    - React-logger (= 0.69.10)
-    - React-perflogger (= 0.69.10)
-    - React-runtimeexecutor (= 0.69.10)
-  - React-jsi (0.69.10):
+    - React-callinvoker (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-jsinspector (= 0.69.12)
+    - React-logger (= 0.69.12)
+    - React-perflogger (= 0.69.12)
+    - React-runtimeexecutor (= 0.69.12)
+  - React-jsi (0.69.12):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.69.10)
-  - React-jsi/Default (0.69.10):
+    - React-jsi/Default (= 0.69.12)
+  - React-jsi/Default (0.69.12):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.69.10):
+  - React-jsiexecutor (0.69.12):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-perflogger (= 0.69.10)
-  - React-jsinspector (0.69.10)
-  - React-logger (0.69.10):
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-perflogger (= 0.69.12)
+  - React-jsinspector (0.69.12)
+  - React-logger (0.69.12):
     - glog
-  - React-perflogger (0.69.10)
-  - React-RCTActionSheet (0.69.10):
-    - React-Core/RCTActionSheetHeaders (= 0.69.10)
-  - React-RCTAnimation (0.69.10):
+  - React-perflogger (0.69.12)
+  - React-RCTActionSheet (0.69.12):
+    - React-Core/RCTActionSheetHeaders (= 0.69.12)
+  - React-RCTAnimation (0.69.12):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.10)
-    - React-Codegen (= 0.69.10)
-    - React-Core/RCTAnimationHeaders (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - ReactCommon/turbomodule/core (= 0.69.10)
-  - React-RCTBlob (0.69.10):
+    - RCTTypeSafety (= 0.69.12)
+    - React-Codegen (= 0.69.12)
+    - React-Core/RCTAnimationHeaders (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - ReactCommon/turbomodule/core (= 0.69.12)
+  - React-RCTBlob (0.69.12):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.69.10)
-    - React-Core/RCTBlobHeaders (= 0.69.10)
-    - React-Core/RCTWebSocket (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-RCTNetwork (= 0.69.10)
-    - ReactCommon/turbomodule/core (= 0.69.10)
-  - React-RCTImage (0.69.10):
+    - React-Codegen (= 0.69.12)
+    - React-Core/RCTBlobHeaders (= 0.69.12)
+    - React-Core/RCTWebSocket (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-RCTNetwork (= 0.69.12)
+    - ReactCommon/turbomodule/core (= 0.69.12)
+  - React-RCTImage (0.69.12):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.10)
-    - React-Codegen (= 0.69.10)
-    - React-Core/RCTImageHeaders (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-RCTNetwork (= 0.69.10)
-    - ReactCommon/turbomodule/core (= 0.69.10)
-  - React-RCTLinking (0.69.10):
-    - React-Codegen (= 0.69.10)
-    - React-Core/RCTLinkingHeaders (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - ReactCommon/turbomodule/core (= 0.69.10)
-  - React-RCTNetwork (0.69.10):
+    - RCTTypeSafety (= 0.69.12)
+    - React-Codegen (= 0.69.12)
+    - React-Core/RCTImageHeaders (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-RCTNetwork (= 0.69.12)
+    - ReactCommon/turbomodule/core (= 0.69.12)
+  - React-RCTLinking (0.69.12):
+    - React-Codegen (= 0.69.12)
+    - React-Core/RCTLinkingHeaders (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - ReactCommon/turbomodule/core (= 0.69.12)
+  - React-RCTNetwork (0.69.12):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.10)
-    - React-Codegen (= 0.69.10)
-    - React-Core/RCTNetworkHeaders (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - ReactCommon/turbomodule/core (= 0.69.10)
-  - React-RCTSettings (0.69.10):
+    - RCTTypeSafety (= 0.69.12)
+    - React-Codegen (= 0.69.12)
+    - React-Core/RCTNetworkHeaders (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - ReactCommon/turbomodule/core (= 0.69.12)
+  - React-RCTSettings (0.69.12):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.10)
-    - React-Codegen (= 0.69.10)
-    - React-Core/RCTSettingsHeaders (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - ReactCommon/turbomodule/core (= 0.69.10)
-  - React-RCTText (0.69.10):
-    - React-Core/RCTTextHeaders (= 0.69.10)
-  - React-RCTVibration (0.69.10):
+    - RCTTypeSafety (= 0.69.12)
+    - React-Codegen (= 0.69.12)
+    - React-Core/RCTSettingsHeaders (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - ReactCommon/turbomodule/core (= 0.69.12)
+  - React-RCTText (0.69.12):
+    - React-Core/RCTTextHeaders (= 0.69.12)
+  - React-RCTVibration (0.69.12):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.69.10)
-    - React-Core/RCTVibrationHeaders (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - ReactCommon/turbomodule/core (= 0.69.10)
-  - React-runtimeexecutor (0.69.10):
-    - React-jsi (= 0.69.10)
-  - ReactCommon/turbomodule/core (0.69.10):
+    - React-Codegen (= 0.69.12)
+    - React-Core/RCTVibrationHeaders (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - ReactCommon/turbomodule/core (= 0.69.12)
+  - React-runtimeexecutor (0.69.12):
+    - React-jsi (= 0.69.12)
+  - ReactCommon/turbomodule/core (0.69.12):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-bridging (= 0.69.10)
-    - React-callinvoker (= 0.69.10)
-    - React-Core (= 0.69.10)
-    - React-cxxreact (= 0.69.10)
-    - React-jsi (= 0.69.10)
-    - React-logger (= 0.69.10)
-    - React-perflogger (= 0.69.10)
-  - RNCCheckbox (0.5.15):
+    - React-bridging (= 0.69.12)
+    - React-callinvoker (= 0.69.12)
+    - React-Core (= 0.69.12)
+    - React-cxxreact (= 0.69.12)
+    - React-jsi (= 0.69.12)
+    - React-logger (= 0.69.12)
+    - React-perflogger (= 0.69.12)
+  - RNCCheckbox (0.5.16):
     - BEMCheckBox (~> 1.4)
     - React-Core
-  - rokt-react-native-sdk (3.15.4):
+  - rokt-react-native-sdk (3.15.6):
     - React
     - Rokt-Widget (~> 3.15.4)
-  - Rokt-Widget (3.15.4)
+  - Rokt-Widget (3.15.6)
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -517,8 +517,8 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FBLazyVector: a8af91c2b5a0029d12ff6b32e428863d63c48991
-  FBReactNativeSpec: ec5e878f6452a3de5430e0b2324a4d4ae6ac63f6
+  FBLazyVector: 6fab494fa11340bd4206edaebed07279a6bafad4
+  FBReactNativeSpec: 76d7b03876b0ad0b86bc5c84d23af8e64db8e096
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
@@ -533,36 +533,36 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
-  RCTRequired: 3581db0757e7ff9be10718a56b3d79b6a6bd3bdf
-  RCTTypeSafety: ce13e630c48340401ebfb28710959913f74b8b36
-  React: cca8f2b7cce018f79847ca79847fa367b206e8a1
-  React-bridging: b893643f09d3964afba6c347e00dd86cf10691e5
-  React-callinvoker: 9ac7cba30428eddf7a06d1253f8e7561b5c97334
-  React-Codegen: 65ff9fbddf8a17a6d4f495f71d365288f934a93a
-  React-Core: 550b694774bc778b5c7bf7608fc12a484e01ec05
-  React-CoreModules: c332d5b416cb3ccf972e7af79d496498a700e073
-  React-cxxreact: c5c4106bfd2d0cee80b848e33b7ff4e35a721b16
-  React-jsi: 6ff3fb9b9764a499c959e0096c0d384fa2b4beef
-  React-jsiexecutor: 388f1c99404c848141d7ea162f61233d04829ede
-  React-jsinspector: a4463b3411b8b9b37153255ef694a84c77ba3c7f
-  React-logger: 2a0497622cbabc47fb769d97620952df14c1f814
-  React-perflogger: bc57c4a953c1ec913b0d984cf4f2b9842a12bde0
-  React-RCTActionSheet: 3efa3546119a1050f6c34a461b386dd9e36eaf0b
-  React-RCTAnimation: e58fb9f1adf7b38af329881ea2740f43ffeea854
-  React-RCTBlob: d2238645553c3ec787324268c0676148d86e6cc4
-  React-RCTImage: e6d7c9ab978cae99364fcc96b9238fc7740a13da
-  React-RCTLinking: 329e88ce217dad464ef34b5d0c40b3ceaac6c9ec
-  React-RCTNetwork: c8967f2382aac31761ddb750fee53fa34cf7a4ee
-  React-RCTSettings: 8a825b4b5ea58f6713a7c97eea6cc82e9895188b
-  React-RCTText: ffcaac5c66bc065f2ccf79b6fe34585adb9e589b
-  React-RCTVibration: 0039c986626b78242401931bb23c803935fae9d1
-  React-runtimeexecutor: 5ebf1ddaa706bf2986123f22d2cad905443c2c5f
-  ReactCommon: 65754b8932ea80272714988268bbfb9f303264a5
-  RNCCheckbox: 43bcc6493611468af0e19f19f029dab3da8561c4
-  rokt-react-native-sdk: b8c489a42337237d7e9182b4c456085107f4618f
-  Rokt-Widget: f97d213aada76628a56133e3046d0accfd02c09c
+  RCTRequired: b9e53f0512019150020156fa0dacd6583ab838be
+  RCTTypeSafety: 04b72202bef8302802610dee70bb9407a245b64c
+  React: 59288a7ca8104eb8002f01378606fe42eeabf4b5
+  React-bridging: b042b8c217f04e568409786de5f221793be49c31
+  React-callinvoker: c7b83d582112e2d5a049dc46abf4c64d871b5c45
+  React-Codegen: 5747238d0446e3ab1deb967e749a2bfde6a5c866
+  React-Core: d8e1250039d47112513757038d9d9f9b638565c6
+  React-CoreModules: 63cceb0040ec2b43a258113193be91f934b37f1b
+  React-cxxreact: 429404aac55d8bffca77328002452fc7fa8b29e8
+  React-jsi: a8f60feb519ac00085eb9a39d20eaa65c96b51ea
+  React-jsiexecutor: ce0b9aa647bdf94126eb2ee1f235d329eb8c0aec
+  React-jsinspector: f275698149311abc8c32ebb97797d6b97c44adde
+  React-logger: da69d7f1c9501c78cd60776d52a60d7fa5e4d9c2
+  React-perflogger: 5ade0a1627352f1647d283e78331819bb46cceae
+  React-RCTActionSheet: 8e94f1e46e09c7035b81fe56c0ed8d78f3ccd340
+  React-RCTAnimation: bf2af72f03cf16528db9a830be69fa04b341a1b7
+  React-RCTBlob: 4d076b8bb55e631ad1280280ecba674fb1e46d16
+  React-RCTImage: 073dcc1689466851fe120c7f8a3cfe3db0196c9f
+  React-RCTLinking: 8872818dc894a17bf17cb4b120f76917bf2e9f0a
+  React-RCTNetwork: 1e9c873f4a210784a4fb752194cb595502112464
+  React-RCTSettings: 1475a717c54f4a9ed627dffffad2470c4b15a419
+  React-RCTText: ed34088172126f84130eea859d62fedca0dd7975
+  React-RCTVibration: c9cd9f21bbcb3b9c6deedbb66f13e373f57dd795
+  React-runtimeexecutor: ea78653fbc68bd6f2d3f5e7e311bc5a9dc8bfeca
+  ReactCommon: f4bb9e5209ea5c3c6ab25e100895119e58d6e50a
+  RNCCheckbox: 75255b03e604bbcc26411eb31c4cbe3e3865f538
+  rokt-react-native-sdk: 3efa27914144de8023cdacb8f08ee1bc1b19df99
+  Rokt-Widget: b30855b51f194b83282c30c79ffa443b05d29034
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: d24d6184b6b85f742536bd93bd07d69d7b9bb4c1
+  Yoga: 8a90b50af67eaa9fe94fd03e550bfeab06096873
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 46335797f92fa1457b278486af4dc1804badf4d8

--- a/RoktSampleApp/package.json
+++ b/RoktSampleApp/package.json
@@ -12,12 +12,13 @@
   },
   "dependencies": {
     "@react-native-community/checkbox": "^0.5.12",
-    "@rokt/react-native-sdk": "file:../Rokt.Widget/rokt-react-native-sdk-3.15.5.tgz",
+    "@rokt/react-native-sdk": "file:../Rokt.Widget/rokt-react-native-sdk-3.15.6.tgz",
     "crypto-js": "^4.0.0",
     "node-forge": "^1.3.1",
     "react": "18.0.0",
     "react-native": "^0.69.7",
-    "react-native-toast-message": "^2.1.5"
+    "react-native-toast-message": "^2.1.5",
+    "typescript": "^5.2.2"
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",


### PR DESCRIPTION
### Background ###

Instead of having one signature that allows `Map` and `Record`, deprecating the one using `Map` and creating an overload for the one using `Record` to make it clearer to not use `Map` but without removing it entirely since it's a breaking change.

Fixes [MP-2722](https://rokt.atlassian.net/browse/MP-2722)

### What Has Changed: ###

- Deprecated signatures using `Map`
- Added signatures using `Record`
- Also fixed another issue with the placeholder type
- Updated to 3.15.6

### How Has This Been Tested? ###

Checked using a Typescript file that objects are accepted without error and the `Map` signature shows as deprecated.
![image](https://github.com/ROKT/rokt-sdk-react-native/assets/122851605/515163fe-a2d2-4339-94be-d0c828218629)

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.