### PR TITLE
[MP-2598] Automated Pipeline

### DIFF
--- a/.buildkite/bin/create_tag.sh
+++ b/.buildkite/bin/create_tag.sh
@@ -15,6 +15,9 @@ git tag -d "v$1" || true
 git add ./android/build.gradle
 git add rokt-react-native-sdk.podspec
 git add package.json
+cd ../RoktSampleApp
+git add package.json
+git add ios/Podfile.lock
 git commit -m "v$1"
 git tag -a "v$1" -m "Automated release v$1"
 git push origin "v$1"

--- a/.buildkite/bin/create_tag.sh
+++ b/.buildkite/bin/create_tag.sh
@@ -4,7 +4,7 @@ set -eu
 
 # $1 version
 
-WIDGET_DIR="$(dirname $0)/../Rokt.Widget"
+WIDGET_DIR="$(dirname $0)/../../Rokt.Widget"
 
 cd $WIDGET_DIR
 

--- a/.buildkite/bin/create_tag.sh
+++ b/.buildkite/bin/create_tag.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+# $1 version
+
+WIDGET_DIR="$(dirname $0)/../Rokt.Widget"
+
+cd $WIDGET_DIR
+
+git config user.email "buildkite@rokt.com"
+git config user.name "Buildkite"
+
+git tag -d "v$1" || true
+git add ./android/build.gradle
+git add rokt-react-native-sdk.podspec
+git add package.json
+git commit -m "v$1"
+git tag -a "v$1" -m "Automated release v$1"
+git push origin "v$1"

--- a/.buildkite/bin/extract_dist_tag.sh
+++ b/.buildkite/bin/extract_dist_tag.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # Gets the semver label e.g. "1.2.3-alpha.4" gets "alpha"
-# If there is not label, print npm default of "latest"
+# If there is no label, print npm default of "latest"
 
 # $1 New React Native SDK version
 

--- a/.buildkite/bin/extract_dist_tag.sh
+++ b/.buildkite/bin/extract_dist_tag.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eu
+
+# Gets the semver label e.g. "1.2.3-alpha.4" gets "alpha"
+# If there is not label, print npm default of "latest"
+
+# $1 New React Native SDK version
+
+TAG=$(echo $1 | awk -F'[\.|-]' '{print $4}')
+
+if [ -z "$TAG" ] ;
+then
+    echo "latest"
+else
+    echo $TAG
+fi

--- a/.buildkite/bin/update_sample_app.sh
+++ b/.buildkite/bin/update_sample_app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+# $1 New React Native SDK version
+
+cd RoktSampleApp
+perl -pi -e "s/(?<=rokt-react-native-sdk-)(.*)(?=\.tgz)/$1/g" package.json
+npm i
+cd ios
+pod update rokt-react-native-sdk

--- a/.buildkite/bin/update_versions.sh
+++ b/.buildkite/bin/update_versions.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+# $1 Android SDK version
+# $2 build.gradle file location
+# $3 iOS SDK version
+# $4 podspec file location 
+# $5 New React Native version
+
+perl -pi -e "s/(?<=roktsdk:)(.*)(?='\))/$1/g" $2
+perl -pi -e "s/(?<=\"Rokt-Widget\", \"~> )(.*)(?=\")/$3/g" $4
+cd Rokt.Widget
+npm version $5

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -89,7 +89,7 @@ steps:
       - pm2 start --name reactnative npm -- start
       - cd ios && pod install --verbose --repo-update && cd -
       - gem install xcpretty -v 0.3.0
-      - export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/RoktSampleApp.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 14' -scheme RoktSampleApp -parallelizeTargets -configuration Debug -derivedDataPath ios/build -UseModernBuildSystem=YES clean test | xcpretty -k
+      - export RCT_NO_LAUNCH_PACKAGER=true && set -o pipefail && xcodebuild -workspace ios/RoktSampleApp.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 14' -scheme RoktSampleApp -parallelizeTargets -configuration Debug -derivedDataPath ios/build -UseModernBuildSystem=YES clean test | xcpretty -k
       - pm2 stop reactnative && pm2 delete reactnative
     plugins:
       - artifacts#v1.9.0:

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -25,7 +25,7 @@ steps:
       - rbenv local 2.7.6
       - nvm use 16
       - ./.buildkite/bin/update_versions.sh $(buildkite-agent meta-data get ANDROID_VERSION) Rokt.Widget/android/build.gradle $(buildkite-agent meta-data get IOS_VERSION) Rokt.Widget/rokt-react-native-sdk.podspec $(buildkite-agent meta-data get VERSION)
-      -  cd Rokt.Widget && npm install && npm run build && npm pack && cd -
+      - cd Rokt.Widget && npm install && npm run build && npm pack && cd -
       - ./.buildkite/bin/update_sample_app.sh $(buildkite-agent meta-data get VERSION)
       - ./.buildkite/bin/create_tag.sh $(buildkite-agent meta-data get VERSION)
     depends_on: 'lint'
@@ -35,69 +35,73 @@ steps:
     agents:
       queue: ${MAC_BK_AGENT}
   
-  # - label: ":android: Android Build and Test"
-  #   key: "android-test"
-  #   depends_on: "pack"
-  #   commands:
-  #     - cd RoktSampleApp
-  #     - npm install
-  #     - cd android
-  #     - gem install fastlane
-  #     - bundle install
-  #     - bundle exec fastlane deviceFarmUITest
-  #   plugins:
-  #     - seek-oss/aws-sm#v2.3.1:
-  #         env:
-  #           DEVICE_FARM_STAGE_ACCESS_KEY:
-  #             secret-id: "stage-react-native-buildkite"
-  #             json-key: ".DEVICE_FARM_STAGE_ACCESS_KEY"
-  #           DEVICE_FARM_STAGE_SECRET_KEY:
-  #             secret-id: "stage-react-native-buildkite"
-  #             json-key: ".DEVICE_FARM_STAGE_SECRET_KEY"
-  #           DEVICE_FARM_STAGE_DEVICE_POOL:
-  #             secret-id: "stage-react-native-buildkite"
-  #             json-key: ".DEVICE_FARM_STAGE_DEVICE_POOL"
-  #           DEVICE_FARM_STAGE_PROJECT_NAME:
-  #             secret-id: "stage-react-native-buildkite"
-  #             json-key: ".DEVICE_FARM_STAGE_PROJECT_NAME"
-  #     - artifacts#v1.9.0:
-  #         download: "Rokt.Widget/*.tgz"
-  #         upload: "RoktSampleApp/android/app/build/outputs/apk/debug"
-  #     - docker#v5.6.0:
-  #         image: "${ECR_HOST}/cached/reactnativecommunity/react-native-android:7.0"
-  #         user: "root"
-  #         mount-buildkite-agent: true
-  #         environment:
-  #           - DEVICE_FARM_STAGE_ACCESS_KEY
-  #           - DEVICE_FARM_STAGE_SECRET_KEY
-  #           - DEVICE_FARM_STAGE_DEVICE_POOL
-  #           - DEVICE_FARM_STAGE_PROJECT_NAME
-  #   agents:
-  #     queue: ${ENG_BK_AGENT}
-  #   timeout_in_minutes: 45
+  - label: ":android: Android Build and Test"
+    key: "android-test"
+    depends_on: "tag"
+    commands:
+      - git fetch --all --tags --force
+      - git checkout "v$(buildkite-agent meta-data get VERSION)"
+      - cd RoktSampleApp
+      - npm install
+      - cd android
+      - gem install fastlane
+      - bundle install
+      - bundle exec fastlane deviceFarmUITest
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            DEVICE_FARM_STAGE_ACCESS_KEY:
+              secret-id: "stage-react-native-buildkite"
+              json-key: ".DEVICE_FARM_STAGE_ACCESS_KEY"
+            DEVICE_FARM_STAGE_SECRET_KEY:
+              secret-id: "stage-react-native-buildkite"
+              json-key: ".DEVICE_FARM_STAGE_SECRET_KEY"
+            DEVICE_FARM_STAGE_DEVICE_POOL:
+              secret-id: "stage-react-native-buildkite"
+              json-key: ".DEVICE_FARM_STAGE_DEVICE_POOL"
+            DEVICE_FARM_STAGE_PROJECT_NAME:
+              secret-id: "stage-react-native-buildkite"
+              json-key: ".DEVICE_FARM_STAGE_PROJECT_NAME"
+      - artifacts#v1.9.0:
+          download: "Rokt.Widget/*.tgz"
+          upload: "RoktSampleApp/android/app/build/outputs/apk/debug"
+      - docker#v5.6.0:
+          image: "${ECR_HOST}/cached/reactnativecommunity/react-native-android:7.0"
+          user: "root"
+          mount-buildkite-agent: true
+          environment:
+            - DEVICE_FARM_STAGE_ACCESS_KEY
+            - DEVICE_FARM_STAGE_SECRET_KEY
+            - DEVICE_FARM_STAGE_DEVICE_POOL
+            - DEVICE_FARM_STAGE_PROJECT_NAME
+    agents:
+      queue: ${ENG_BK_AGENT}
+    timeout_in_minutes: 45
 
-  # - label: ":ios: iOS Build and Test"
-  #   key: "ios-test"
-  #   depends_on: "pack"
-  #   commands:
-  #     - . ~/.zshrc
-  #     - rbenv local 2.7.6
-  #     - cd RoktSampleApp
-  #     - xcrun simctl boot "iPhone 14" || true
-  #     - nvm use 12
-  #     - npm install pm2 -g
-  #     - npm install
-  #     - pm2 start --name reactnative npm -- start
-  #     - cd ios && pod install --verbose --repo-update && cd -
-  #     - gem install xcpretty -v 0.3.0
-  #     - export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/RoktSampleApp.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 14' -scheme RoktSampleApp -parallelizeTargets -configuration Debug -derivedDataPath ios/build -UseModernBuildSystem=YES clean test | xcpretty -k
-  #     - pm2 stop reactnative && pm2 delete reactnative
-  #   plugins:
-  #     - artifacts#v1.9.0:
-  #         download: "Rokt.Widget/*.tgz"
-  #   agents:
-  #     queue: ${MAC_BK_AGENT}
-  #   timeout_in_minutes: 45
+  - label: ":ios: iOS Build and Test"
+    key: "ios-test"
+    depends_on: "tag"
+    commands:
+      - . ~/.zshrc
+      - rbenv local 2.7.6
+      - git fetch --all --tags --force
+      - git checkout "v$(buildkite-agent meta-data get VERSION)"
+      - cd RoktSampleApp
+      - xcrun simctl boot "iPhone 14" || true
+      - nvm use 12
+      - npm install pm2 -g
+      - npm install
+      - pm2 start --name reactnative npm -- start
+      - cd ios && pod install --verbose --repo-update && cd -
+      - gem install xcpretty -v 0.3.0
+      - export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/RoktSampleApp.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 14' -scheme RoktSampleApp -parallelizeTargets -configuration Debug -derivedDataPath ios/build -UseModernBuildSystem=YES clean test | xcpretty -k
+      - pm2 stop reactnative && pm2 delete reactnative
+    plugins:
+      - artifacts#v1.9.0:
+          download: "Rokt.Widget/*.tgz"
+    agents:
+      queue: ${MAC_BK_AGENT}
+    timeout_in_minutes: 45
 
   # - block: ":whale: Publish Alpha Version to npm"
   #   key: "alpha-block"

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -105,9 +105,9 @@ steps:
     timeout_in_minutes: 45
 
   - label: ":npm: Publish to npm"
-    depends_on:
-      - "android-test"
-      - "ios-test"
+    depends_on: ~
+      # - "android-test"
+      # - "ios-test"
     commands:
       - git fetch --all --tags --force
       - git checkout "v$(buildkite-agent meta-data get VERSION)"
@@ -118,7 +118,7 @@ steps:
       - cd android
       - gem install fastlane
       - bundle install
-      - bundle exec fastlane automatedPublish dist_tag:$(./.buildkite/bin/extract_dist_tag $(buildkite-agent meta-data get VERSION))
+      - bundle exec fastlane automatedPublish dist_tag:$(../.buildkite/bin/extract_dist_tag $(buildkite-agent meta-data get VERSION))
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -23,33 +23,17 @@ steps:
     commands:
       - . ~/.zshrc
       - rbenv local 2.7.6
-      - nvm use 12
+      - nvm use 16
       - ./.buildkite/bin/update_versions.sh $(buildkite-agent meta-data get ANDROID_VERSION) Rokt.Widget/android/build.gradle $(buildkite-agent meta-data get IOS_VERSION) Rokt.Widget/rokt-react-native-sdk.podspec $(buildkite-agent meta-data get VERSION)
+      - npm install && npm run build && npm pack
       - ./.buildkite/bin/update_sample_app.sh $(buildkite-agent meta-data get VERSION)
       - ./.buildkite/bin/create_tag.sh $(buildkite-agent meta-data get VERSION)
     depends_on: 'lint'
-    agents:
-      queue: ${MAC_BK_AGENT}
-    
-  - label: ":package: Create Tarball"
-    key: "pack"
-    depends_on: "lint"
-    commands:
-      - git fetch --all --tags --force
-      - git checkout "v$(buildkite-agent meta-data get VERSION)"
-      - cd Rokt.Widget
-      - npm install && npm run build && npm pack
     plugins:
-      - docker#v5.6.0:
-          image: "${ECR_HOST}/cached/node:17.2.0-bullseye"
-          user: "root"
-          mount-buildkite-agent: true
-          mount-ssh-agent: true
       - artifacts#v1.9.0:
           upload: "Rokt.Widget/*.tgz"
     agents:
-      queue: ${ENG_BK_AGENT}
-    timeout_in_minutes: 15
+      queue: ${MAC_BK_AGENT}
   
   # - label: ":android: Android Build and Test"
   #   key: "android-test"

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -95,7 +95,7 @@ steps:
       - pm2 start --name reactnative npm -- start
       - cd ios && pod install --verbose --repo-update && cd -
       - gem install xcpretty -v 0.3.0
-      - export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/RoktSampleApp.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 14' -scheme RoktSampleApp -parallelizeTargets -configuration Debug -derivedDataPath ios/build -UseModernBuildSystem=YES clean test | xcpretty -k
+      - export RCT_NO_LAUNCH_PACKAGER=true && set -o pipefail && xcodebuild -workspace ios/RoktSampleApp.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 14' -scheme RoktSampleApp -parallelizeTargets -configuration Debug -derivedDataPath ios/build -UseModernBuildSystem=YES clean test | xcpretty -k
       - pm2 stop reactnative && pm2 delete reactnative
     plugins:
       - artifacts#v1.9.0:

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -18,14 +18,14 @@ steps:
       queue: ${ENG_BK_AGENT}
     timeout_in_minutes: 15
 
-  - name: ':git: Create git tag'
-  key: 'tag'
-  commands:
-    - ./.buildkite/bin/update_versions.sh $(buildkite-agent meta-data get ANDROID_VERSION) Rokt.Widget/android/build.gradle $(buildkite-agent meta-data get IOS_VERSION) Rokt.Widget/rokt-react-native-sdk.podspec $(buildkite-agent meta-data get VERSION)
-    - ./.buildkite/bin/create_tag.sh $(buildkite-agent meta-data get VERSION)
-  depends_on: 'lint'
-  agents:
-    queue: ${MAC_BK_AGENT}
+  - label: ':git: Create git tag'
+    key: 'tag'
+    commands:
+      - ./.buildkite/bin/update_versions.sh $(buildkite-agent meta-data get ANDROID_VERSION) Rokt.Widget/android/build.gradle $(buildkite-agent meta-data get IOS_VERSION) Rokt.Widget/rokt-react-native-sdk.podspec $(buildkite-agent meta-data get VERSION)
+      - ./.buildkite/bin/create_tag.sh $(buildkite-agent meta-data get VERSION)
+    depends_on: 'lint'
+    agents:
+      queue: ${MAC_BK_AGENT}
     
   - label: ":package: Create Tarball"
     key: "pack"

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -69,6 +69,7 @@ steps:
           image: "${ECR_HOST}/cached/reactnativecommunity/react-native-android:7.0"
           user: "root"
           mount-buildkite-agent: true
+          mount-ssh-agent: true
           environment:
             - DEVICE_FARM_STAGE_ACCESS_KEY
             - DEVICE_FARM_STAGE_SECRET_KEY

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -18,8 +18,8 @@ steps:
       queue: ${ENG_BK_AGENT}
     timeout_in_minutes: 15
 
-  - label: ':git: Create git tag'
-    key: 'tag'
+  - label: ":git: Create git tag"
+    key: "tag"
     commands:
       - . ~/.zshrc
       - rbenv local 2.7.6
@@ -28,13 +28,13 @@ steps:
       - cd Rokt.Widget && npm install && npm run build && npm pack && cd -
       - ./.buildkite/bin/update_sample_app.sh $(buildkite-agent meta-data get VERSION)
       - ./.buildkite/bin/create_tag.sh $(buildkite-agent meta-data get VERSION)
-    depends_on: 'lint'
+    depends_on: "lint"
     plugins:
       - artifacts#v1.9.0:
           upload: "Rokt.Widget/*.tgz"
     agents:
       queue: ${MAC_BK_AGENT}
-  
+
   - label: ":android: Android Build and Test"
     key: "android-test"
     depends_on: "tag"

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -23,7 +23,9 @@ steps:
     commands:
       - . ~/.zshrc
       - rbenv local 2.7.6
+      - nvm use 12
       - ./.buildkite/bin/update_versions.sh $(buildkite-agent meta-data get ANDROID_VERSION) Rokt.Widget/android/build.gradle $(buildkite-agent meta-data get IOS_VERSION) Rokt.Widget/rokt-react-native-sdk.podspec $(buildkite-agent meta-data get VERSION)
+      - ./.buildkite/bin/update_sample_app.sh $(buildkite-agent meta-data get VERSION)
       - ./.buildkite/bin/create_tag.sh $(buildkite-agent meta-data get VERSION)
     depends_on: 'lint'
     agents:

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -105,9 +105,9 @@ steps:
     timeout_in_minutes: 45
 
   - label: ":npm: Publish to npm"
-    depends_on: "tag"
-      # - "android-test"
-      # - "ios-test"
+    depends_on:
+      - "android-test"
+      - "ios-test"
     commands:
       - git fetch --all --tags --force
       - git checkout "v$(buildkite-agent meta-data get VERSION)"
@@ -135,73 +135,3 @@ steps:
     agents:
       queue: ${ENG_BK_AGENT}
     timeout_in_minutes: 45
-
-  # - block: ":whale: Publish Alpha Version to npm"
-  #   key: "alpha-block"
-  #   prompt: "Confirm publishing alpha version to npm?"
-  #   depends_on:
-  #     - "android-test"
-  #     - "ios-test"
-  
-  # - label: ":npm: Publish Alpha Version to npm"
-  #   depends_on: "alpha-block"
-  #   commands:
-  #     - cd Rokt.Widget
-  #     - npm install && npm run build && npm pack
-  #     - cd - && cd RoktSampleApp
-  #     - npm install
-  #     - cd android
-  #     - gem install fastlane
-  #     - bundle install
-  #     - bundle exec fastlane publishAlphaSDK
-  #   plugins:
-  #     - seek-oss/aws-sm#v2.3.1:
-  #         env:
-  #           NPM_TOKEN:
-  #             secret-id: "stage-react-native-buildkite"
-  #             json-key: ".NPM_TOKEN"
-  #     - docker#v5.6.0:
-  #         image: "${ECR_HOST}/cached/reactnativecommunity/react-native-android:7.0"
-  #         user: "root"
-  #         mount-buildkite-agent: true
-  #         environment:
-  #           - NPM_TOKEN
-  #   agents:
-  #     queue: ${ENG_BK_AGENT}
-  #   timeout_in_minutes: 45
-  
-  # - block: ":whale: Publish to npm"
-  #   key: "publish-block"
-  #   prompt: "Confirm publishing to npm?"
-  #   depends_on:
-  #     - "android-test"
-  #     - "ios-test"
-  #   if: build.message =~ /hotfix/i || build.branch =~ /^release/i
-  
-  # - label: ":npm: Publish to npm"
-  #   depends_on: "publish-block"
-  #   if: build.message =~ /hotfix/i || build.branch =~ /^release/i
-  #   commands:
-  #     - cd Rokt.Widget
-  #     - npm install && npm run build && npm pack
-  #     - cd - && cd RoktSampleApp
-  #     - npm install
-  #     - cd android
-  #     - gem install fastlane
-  #     - bundle install
-  #     - bundle exec fastlane publishSDK
-  #   plugins:
-  #     - seek-oss/aws-sm#v2.3.1:
-  #         env:
-  #           NPM_TOKEN:
-  #             secret-id: "stage-react-native-buildkite"
-  #             json-key: ".NPM_TOKEN"
-  #     - docker#v5.6.0:
-  #         image: "${ECR_HOST}/cached/reactnativecommunity/react-native-android:7.0"
-  #         user: "root"
-  #         mount-buildkite-agent: true
-  #         environment:
-  #           - NPM_TOKEN
-  #   agents:
-  #     queue: ${ENG_BK_AGENT}
-  #   timeout_in_minutes: 45

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -21,6 +21,8 @@ steps:
   - label: ':git: Create git tag'
     key: 'tag'
     commands:
+      - . ~/.zshrc
+      - rbenv local 2.7.6
       - ./.buildkite/bin/update_versions.sh $(buildkite-agent meta-data get ANDROID_VERSION) Rokt.Widget/android/build.gradle $(buildkite-agent meta-data get IOS_VERSION) Rokt.Widget/rokt-react-native-sdk.podspec $(buildkite-agent meta-data get VERSION)
       - ./.buildkite/bin/create_tag.sh $(buildkite-agent meta-data get VERSION)
     depends_on: 'lint'

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -25,7 +25,7 @@ steps:
       - rbenv local 2.7.6
       - nvm use 16
       - ./.buildkite/bin/update_versions.sh $(buildkite-agent meta-data get ANDROID_VERSION) Rokt.Widget/android/build.gradle $(buildkite-agent meta-data get IOS_VERSION) Rokt.Widget/rokt-react-native-sdk.podspec $(buildkite-agent meta-data get VERSION)
-      - npm install && npm run build && npm pack
+      -  cd Rokt.Widget && npm install && npm run build && npm pack && cd -
       - ./.buildkite/bin/update_sample_app.sh $(buildkite-agent meta-data get VERSION)
       - ./.buildkite/bin/create_tag.sh $(buildkite-agent meta-data get VERSION)
     depends_on: 'lint'

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -104,6 +104,38 @@ steps:
       queue: ${MAC_BK_AGENT}
     timeout_in_minutes: 45
 
+  - label: ":npm: Publish to npm"
+    depends_on:
+      - "android-test"
+      - "ios-test"
+    commands:
+      - git fetch --all --tags --force
+      - git checkout "v$(buildkite-agent meta-data get VERSION)"
+      - cd Rokt.Widget
+      - npm install && npm run build && npm pack
+      - cd - && cd RoktSampleApp
+      - npm install
+      - cd android
+      - gem install fastlane
+      - bundle install
+      - bundle exec fastlane automatedPublish dist_tag:$(./.buildkite/bin/extract_dist_tag $(buildkite-agent meta-data get VERSION))
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            NPM_TOKEN:
+              secret-id: "stage-react-native-buildkite"
+              json-key: ".NPM_TOKEN"
+      - docker#v5.6.0:
+          image: "${ECR_HOST}/cached/reactnativecommunity/react-native-android:7.0"
+          user: "root"
+          mount-buildkite-agent: true
+          mount-ssh-agent: true
+          environment:
+            - NPM_TOKEN
+    agents:
+      queue: ${ENG_BK_AGENT}
+    timeout_in_minutes: 45
+
   # - block: ":whale: Publish Alpha Version to npm"
   #   key: "alpha-block"
   #   prompt: "Confirm publishing alpha version to npm?"

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -105,7 +105,7 @@ steps:
     timeout_in_minutes: 45
 
   - label: ":npm: Publish to npm"
-    depends_on: ~
+    depends_on: "tag"
       # - "android-test"
       # - "ios-test"
     commands:

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -118,7 +118,7 @@ steps:
       - cd android
       - gem install fastlane
       - bundle install
-      - bundle exec fastlane automatedPublish dist_tag:$(../../.buildkite/bin/extract_dist_tag $(buildkite-agent meta-data get VERSION))
+      - bundle exec fastlane automatedPublish dist_tag:$(../../.buildkite/bin/extract_dist_tag.sh $(buildkite-agent meta-data get VERSION))
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -118,7 +118,7 @@ steps:
       - cd android
       - gem install fastlane
       - bundle install
-      - bundle exec fastlane automatedPublish dist_tag:$(../.buildkite/bin/extract_dist_tag $(buildkite-agent meta-data get VERSION))
+      - bundle exec fastlane automatedPublish dist_tag:$(../../.buildkite/bin/extract_dist_tag $(buildkite-agent meta-data get VERSION))
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -1,0 +1,182 @@
+env:
+  ENG_ACCOUNT: "035088524874"
+  ECR_HOST: ${ENG_ACCOUNT}.dkr.ecr.us-west-2.amazonaws.com
+  MAC_BK_AGENT: eng-prod-us-west-2-mac-arm-macos-build-medium
+  ENG_BK_AGENT: eng-default
+
+steps:
+  - label: ":tslint: Lint"
+    key: "lint"
+    commands:
+      - cd Rokt.Widget
+      - npm install && npm run lint
+    plugins:
+      - docker#v5.6.0:
+          image: "${ECR_HOST}/cached/node:17.2.0-alpine"
+          user: "root"
+    agents:
+      queue: ${ENG_BK_AGENT}
+    timeout_in_minutes: 15
+
+  - name: ':git: Create git tag'
+  key: 'tag'
+  commands:
+    - ./.buildkite/bin/update_versions.sh $(buildkite-agent meta-data get ANDROID_VERSION) Rokt.Widget/android/build.gradle $(buildkite-agent meta-data get IOS_VERSION) Rokt.Widget/rokt-react-native-sdk.podspec $(buildkite-agent meta-data get VERSION)
+    - ./.buildkite/bin/create_tag.sh $(buildkite-agent meta-data get VERSION)
+  depends_on: 'lint'
+  agents:
+    queue: ${MAC_BK_AGENT}
+    
+  - label: ":package: Create Tarball"
+    key: "pack"
+    depends_on: "lint"
+    commands:
+      - git fetch --all --tags --force
+      - git checkout "v$(buildkite-agent meta-data get VERSION)"
+      - cd Rokt.Widget
+      - npm install && npm run build && npm pack
+    plugins:
+      - docker#v5.6.0:
+          image: "${ECR_HOST}/cached/node:17.2.0-bullseye"
+          user: "root"
+          mount-buildkite-agent: true
+          mount-ssh-agent: true
+      - artifacts#v1.9.0:
+          upload: "Rokt.Widget/*.tgz"
+    agents:
+      queue: ${ENG_BK_AGENT}
+    timeout_in_minutes: 15
+  
+  # - label: ":android: Android Build and Test"
+  #   key: "android-test"
+  #   depends_on: "pack"
+  #   commands:
+  #     - cd RoktSampleApp
+  #     - npm install
+  #     - cd android
+  #     - gem install fastlane
+  #     - bundle install
+  #     - bundle exec fastlane deviceFarmUITest
+  #   plugins:
+  #     - seek-oss/aws-sm#v2.3.1:
+  #         env:
+  #           DEVICE_FARM_STAGE_ACCESS_KEY:
+  #             secret-id: "stage-react-native-buildkite"
+  #             json-key: ".DEVICE_FARM_STAGE_ACCESS_KEY"
+  #           DEVICE_FARM_STAGE_SECRET_KEY:
+  #             secret-id: "stage-react-native-buildkite"
+  #             json-key: ".DEVICE_FARM_STAGE_SECRET_KEY"
+  #           DEVICE_FARM_STAGE_DEVICE_POOL:
+  #             secret-id: "stage-react-native-buildkite"
+  #             json-key: ".DEVICE_FARM_STAGE_DEVICE_POOL"
+  #           DEVICE_FARM_STAGE_PROJECT_NAME:
+  #             secret-id: "stage-react-native-buildkite"
+  #             json-key: ".DEVICE_FARM_STAGE_PROJECT_NAME"
+  #     - artifacts#v1.9.0:
+  #         download: "Rokt.Widget/*.tgz"
+  #         upload: "RoktSampleApp/android/app/build/outputs/apk/debug"
+  #     - docker#v5.6.0:
+  #         image: "${ECR_HOST}/cached/reactnativecommunity/react-native-android:7.0"
+  #         user: "root"
+  #         mount-buildkite-agent: true
+  #         environment:
+  #           - DEVICE_FARM_STAGE_ACCESS_KEY
+  #           - DEVICE_FARM_STAGE_SECRET_KEY
+  #           - DEVICE_FARM_STAGE_DEVICE_POOL
+  #           - DEVICE_FARM_STAGE_PROJECT_NAME
+  #   agents:
+  #     queue: ${ENG_BK_AGENT}
+  #   timeout_in_minutes: 45
+
+  # - label: ":ios: iOS Build and Test"
+  #   key: "ios-test"
+  #   depends_on: "pack"
+  #   commands:
+  #     - . ~/.zshrc
+  #     - rbenv local 2.7.6
+  #     - cd RoktSampleApp
+  #     - xcrun simctl boot "iPhone 14" || true
+  #     - nvm use 12
+  #     - npm install pm2 -g
+  #     - npm install
+  #     - pm2 start --name reactnative npm -- start
+  #     - cd ios && pod install --verbose --repo-update && cd -
+  #     - gem install xcpretty -v 0.3.0
+  #     - export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/RoktSampleApp.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 14' -scheme RoktSampleApp -parallelizeTargets -configuration Debug -derivedDataPath ios/build -UseModernBuildSystem=YES clean test | xcpretty -k
+  #     - pm2 stop reactnative && pm2 delete reactnative
+  #   plugins:
+  #     - artifacts#v1.9.0:
+  #         download: "Rokt.Widget/*.tgz"
+  #   agents:
+  #     queue: ${MAC_BK_AGENT}
+  #   timeout_in_minutes: 45
+
+  # - block: ":whale: Publish Alpha Version to npm"
+  #   key: "alpha-block"
+  #   prompt: "Confirm publishing alpha version to npm?"
+  #   depends_on:
+  #     - "android-test"
+  #     - "ios-test"
+  
+  # - label: ":npm: Publish Alpha Version to npm"
+  #   depends_on: "alpha-block"
+  #   commands:
+  #     - cd Rokt.Widget
+  #     - npm install && npm run build && npm pack
+  #     - cd - && cd RoktSampleApp
+  #     - npm install
+  #     - cd android
+  #     - gem install fastlane
+  #     - bundle install
+  #     - bundle exec fastlane publishAlphaSDK
+  #   plugins:
+  #     - seek-oss/aws-sm#v2.3.1:
+  #         env:
+  #           NPM_TOKEN:
+  #             secret-id: "stage-react-native-buildkite"
+  #             json-key: ".NPM_TOKEN"
+  #     - docker#v5.6.0:
+  #         image: "${ECR_HOST}/cached/reactnativecommunity/react-native-android:7.0"
+  #         user: "root"
+  #         mount-buildkite-agent: true
+  #         environment:
+  #           - NPM_TOKEN
+  #   agents:
+  #     queue: ${ENG_BK_AGENT}
+  #   timeout_in_minutes: 45
+  
+  # - block: ":whale: Publish to npm"
+  #   key: "publish-block"
+  #   prompt: "Confirm publishing to npm?"
+  #   depends_on:
+  #     - "android-test"
+  #     - "ios-test"
+  #   if: build.message =~ /hotfix/i || build.branch =~ /^release/i
+  
+  # - label: ":npm: Publish to npm"
+  #   depends_on: "publish-block"
+  #   if: build.message =~ /hotfix/i || build.branch =~ /^release/i
+  #   commands:
+  #     - cd Rokt.Widget
+  #     - npm install && npm run build && npm pack
+  #     - cd - && cd RoktSampleApp
+  #     - npm install
+  #     - cd android
+  #     - gem install fastlane
+  #     - bundle install
+  #     - bundle exec fastlane publishSDK
+  #   plugins:
+  #     - seek-oss/aws-sm#v2.3.1:
+  #         env:
+  #           NPM_TOKEN:
+  #             secret-id: "stage-react-native-buildkite"
+  #             json-key: ".NPM_TOKEN"
+  #     - docker#v5.6.0:
+  #         image: "${ECR_HOST}/cached/reactnativecommunity/react-native-android:7.0"
+  #         user: "root"
+  #         mount-buildkite-agent: true
+  #         environment:
+  #           - NPM_TOKEN
+  #   agents:
+  #     queue: ${ENG_BK_AGENT}
+  #   timeout_in_minutes: 45

--- a/Rokt.Widget/README_PUBLISHING.md
+++ b/Rokt.Widget/README_PUBLISHING.md
@@ -25,6 +25,10 @@ This SDK is published to a NPM package repository. The publishing step uses the 
 The steps are configured in `publish.gradle`.
 Publishing  Alpha and prod are possible through Buildkite based on the Git branch names as explained in above step.
 
+## Automated Publishing
+The SDK can be released via the [Mobile Release Pipeline](https://github.com/ROKT/mobile-release-pipeline). Follow the instructions in the Mobile Release Pipeline repo to release. You can still release the SDK manually by following the steps in the previous section.  
+The appropriate dist tag will be applied automatically when publishing if one is set (e.g. `1.2.3-alpha.1` will set the dist tag as `alpha`). If not, the default `latest` tag will be used.
+
 ## Local Setup
 Go to the root of the project **Rokt.Widget** " and run ```npm install```.
 This will install all required packages for the project.  

--- a/RoktSampleApp/android/fastlane/Fastfile
+++ b/RoktSampleApp/android/fastlane/Fastfile
@@ -75,7 +75,7 @@ platform :android do
             ENV['NPM_TOKEN'] = ENV['NPM_TOKEN']
 
             sh("echo \"//registry.npmjs.org/:_authToken=$NPM_TOKEN\" > ./.npmrc")
-            sh("npm publish --dry-run --access=public --tag="+dist_tag)
+            sh("npm publish --access=public --tag="+dist_tag)
          end
       end
 end

--- a/RoktSampleApp/android/fastlane/Fastfile
+++ b/RoktSampleApp/android/fastlane/Fastfile
@@ -67,4 +67,15 @@ platform :android do
 	     sh("npm publish --tag alpha")
         end  
    end
+
+   desc "Automated publish to npm"
+      lane :automatedPublish do |options|
+         dist_tag = options[:dist_tag]
+         Dir.chdir("../../../Rokt.Widget") do
+            ENV['NPM_TOKEN'] = ENV['NPM_TOKEN']
+
+            sh("echo \"//registry.npmjs.org/:_authToken=$NPM_TOKEN\" > ./.npmrc")
+            sh("npm publish --dry-run --access=public --tag="+dist_tag)
+         end
+      end
 end


### PR DESCRIPTION
### Background ###

Adding automated release pipeline. It works similar to the other pipelines. 

Fixes [MP-2598](https://rokt.atlassian.net/browse/MP-2598)

### What Has Changed: ###

- Generate tag with updated native SDK versions and sample app
- Extracting semver label to use as npm dist tag so alpha, beta etc. can be released from the same pipeline.

### How Has This Been Tested? ###

Published an alpha: 
https://buildkite.com/rokt/react-native-sdk/builds/223
https://www.npmjs.com/package/@rokt/react-native-sdk/v/3.15.3-alpha.2/

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.