### PR TITLE
MP-3168 - Add onUnload event reason in the callback

### DIFF
--- a/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetModule.java
+++ b/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetModule.java
@@ -188,31 +188,34 @@ public class RNRoktWidgetModule extends ReactContextBaseJavaModule {
         Rokt.RoktCallback callback = new Rokt.RoktCallback() {
             @Override
             public void onLoad() {
-                sendCallback("onLoad");
+                sendCallback("onLoad", null);
             }
 
             @Override
             public void onUnload(@NonNull Rokt.UnloadReasons unloadReasons) {
-                sendCallback("onUnLoad");
+                sendCallback("onUnLoad", unloadReasons.toString());
             }
 
             @Override
             public void onShouldShowLoadingIndicator() {
-                sendCallback("onShouldShowLoadingIndicator");
+                sendCallback("onShouldShowLoadingIndicator", null);
             }
 
             @Override
             public void onShouldHideLoadingIndicator() {
-                sendCallback("onShouldHideLoadingIndicator");
+                sendCallback("onShouldHideLoadingIndicator", null);
             }
         };
         listeners.put(System.currentTimeMillis(), callback);
         return callback;
     }
 
-    private void sendCallback(final String eventValue) {
+    private void sendCallback(final String eventValue, @Nullable final String reason) {
         WritableMap params = Arguments.createMap();
         params.putString("callbackValue", eventValue);
+        if (reason != null) {
+            params.putString("reason", reason);
+        }
         sendEvent(reactContext, "RoktCallback", params);
     }
 


### PR DESCRIPTION
### Background ###

Propagate the unload reason to ReactNative event stream

Fixes [MP-3168](https://rokt.atlassian.net/browse/MP-3168)

### What Has Changed: ###

SDK callback changed

### How Has This Been Tested? ###

Tested locally

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.