### PR TITLE
MP-3269 - Consume `Rokt.events()` and propagate to RN context

### DIFF
--- a/Rokt.Widget/android/build.gradle
+++ b/Rokt.Widget/android/build.gradle
@@ -59,6 +59,6 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
-    implementation ('com.rokt:roktsdk:4.3.0-alpha.1')
+    implementation ('com.rokt:roktsdk:4.3.0-alpha.3')
 }
   

--- a/Rokt.Widget/android/build.gradle
+++ b/Rokt.Widget/android/build.gradle
@@ -58,6 +58,7 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation ('com.rokt:roktsdk:4.2.0')
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
+    implementation ('com.rokt:roktsdk:4.3.0-alpha.1')
 }
   

--- a/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetModule.kt
+++ b/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetModule.kt
@@ -45,7 +45,6 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
         if (currentActivity != null && appVersion != null && roktTagId != null) {
             Rokt.setFrameworkType(ReactNative)
             Rokt.init(roktTagId, appVersion, currentActivity)
-            startRoktEventListener()
         } else {
             logDebug("Activity, roktTagId and AppVersion cannot be null")
         }
@@ -57,7 +56,6 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
         if (currentActivity != null && appVersion != null && roktTagId != null) {
             Rokt.setFrameworkType(ReactNative)
             Rokt.init(roktTagId, appVersion, currentActivity, HashSet(), readableMapToMapOfStrings(fontsMap))
-            startRoktEventListener()
         } else {
             logDebug("Activity, roktTagId and AppVersion cannot be null")
         }
@@ -71,6 +69,7 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
         }
 
         val uiManager = reactContext.getNativeModule(UIManagerModule::class.java)
+        startRoktEventListener(viewName)
         uiManager?.addUIBlock { nativeViewHierarchyManager ->
             Rokt.execute(
                 viewName,
@@ -209,12 +208,13 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
         return placeholderMap
     }
 
-    private fun startRoktEventListener() {
+    private fun startRoktEventListener(viewName: String) {
         (currentActivity as? LifecycleOwner)?.lifecycleScope?.launch {
-            (currentActivity as LifecycleOwner).repeatOnLifecycle(Lifecycle.State.STARTED) {
-                Rokt.roktEvents().collect { event ->
+            (currentActivity as LifecycleOwner).repeatOnLifecycle(Lifecycle.State.CREATED) {
+                Rokt.roktEvents(viewName).collect { event ->
                     val params = Arguments.createMap()
                     params.putString("event", event.javaClass.simpleName)
+                    params.putString("viewName", viewName)
                     sendEvent(reactContext, "RoktEvents", params)
                 }
             }

--- a/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetModule.kt
+++ b/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetModule.kt
@@ -9,11 +9,13 @@ import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import com.facebook.react.uimanager.NativeViewHierarchyManager
 import com.facebook.react.uimanager.UIManagerModule
+import com.rokt.roktsdk.FulfillmentAttributes
 import com.rokt.roktsdk.Rokt
 import com.rokt.roktsdk.Rokt.Environment.Prod
 import com.rokt.roktsdk.Rokt.RoktEventHandler
 import com.rokt.roktsdk.Rokt.RoktEventType
 import com.rokt.roktsdk.Rokt.SdkFrameworkType.ReactNative
+import com.rokt.roktsdk.RoktEvent
 import com.rokt.roktsdk.Widget
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
@@ -33,6 +35,7 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
         reactContext
     ) {
     private var roktEventHandler: RoktEventHandler? = null
+    private var fulfillmentAttributesCallback: FulfillmentAttributes? = null
     private var debug = false
 
     private val listeners: MutableMap<Long, Rokt.RoktCallback> = object : LinkedHashMap<Long, Rokt.RoktCallback>() {
@@ -88,6 +91,7 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
         }
 
         val uiManager = reactContext.getNativeModule(UIManagerModule::class.java)
+        startRoktEventListener(viewName)
         uiManager?.addUIBlock { nativeViewHierarchyManager ->
             Rokt.execute2Step(
                 viewName,
@@ -124,6 +128,12 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
             logDebug("Calling setFulfillmentAttributes")
         } else {
             logDebug("RoktEventHandler is null, make sure you run execute2Step before calling setFulfillmentAttributes")
+        }
+
+        if (fulfillmentAttributesCallback != null) {
+            val fulfillmentAttributes = readableMapToMapOfStrings(attributes)
+            fulfillmentAttributesCallback?.sendAttributes(fulfillmentAttributes)
+            logDebug("Calling setFulfillmentAttributes")
         }
     }
 
@@ -211,9 +221,55 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
     private fun startRoktEventListener(viewName: String) {
         (currentActivity as? LifecycleOwner)?.lifecycleScope?.launch {
             (currentActivity as LifecycleOwner).repeatOnLifecycle(Lifecycle.State.CREATED) {
-                Rokt.roktEvents(viewName).collect { event ->
+                Rokt.events(viewName).collect { event ->
                     val params = Arguments.createMap()
-                    params.putString("event", event.javaClass.simpleName)
+                    var eventName: String = ""
+                    val placementId: String? = when (event) {
+                        is RoktEvent.FirstPositiveEngagement -> {
+                            eventName = "FirstPositiveEngagement"
+                            fulfillmentAttributesCallback = event.fulfillmentAttributes
+                            event.id
+                        }
+                        RoktEvent.HideLoadingIndicator -> {
+                            eventName = "HideLoadingIndicator"
+                            null
+                        }
+                        is RoktEvent.OfferEngagement -> {
+                            eventName = "OfferEngagement"
+                            event.id
+                        }
+                        is RoktEvent.PlacementClosed -> {
+                            eventName = "PlacementClosed"
+                            event.id
+                        }
+                        is RoktEvent.PlacementCompleted -> {
+                            eventName = "PlacementCompleted"
+                            event.id
+                        }
+                        is RoktEvent.PlacementFailure -> {
+                            eventName = "PlacementFailure"
+                            event.id
+                        }
+                        is RoktEvent.PlacementInteractive -> {
+                            eventName = "PlacementInteractive"
+                            event.id
+                        }
+                        is RoktEvent.PlacementReady -> {
+                            eventName = "PlacementReady"
+                            event.id
+                        }
+                        is RoktEvent.PositiveEngagement -> {
+                            eventName = "PositiveEngagement"
+                            event.id
+                        }
+                        RoktEvent.ShowLoadingIndicator -> {
+                            eventName = "ShowLoadingIndicator"
+                            null
+                        }
+                    }
+
+                    placementId?.let { params.putString("placementId", it) }
+                    params.putString("event", eventName)
                     params.putString("viewName", viewName)
                     sendEvent(reactContext, "RoktEvents", params)
                 }

--- a/Rokt.Widget/ios/RNRoktWidget.h
+++ b/Rokt.Widget/ios/RNRoktWidget.h
@@ -14,9 +14,11 @@
 #import <React/RCTBridgeModule.h>
 #endif
 #import <Rokt_Widget/Rokt_Widget-Swift.h>
+#import "RoktEventManager.h"
 
 
 @interface RNRoktWidget : NSObject <RCTBridgeModule>
     @property (nonatomic) RoktEventHandler *roktEventHandler;
+    @property (nonatomic) RoktEventManager * _Nullable eventManager;
 @end
   

--- a/Rokt.Widget/ios/RNRoktWidget.m
+++ b/Rokt.Widget/ios/RNRoktWidget.m
@@ -154,10 +154,14 @@ RCT_EXPORT_METHOD(execute2Step:(NSString *)viewName
 RCT_EXPORT_METHOD(setFulfillmentAttributes:(NSDictionary *)attributes) {
     if (self.roktEventHandler != nil) {
         RCTLogInfo(@"calling setFulfillmentAttributesWithAttributes");
-        [self.roktEventHandler setFulfillmentAttributesWithAttributes:attributes];
+        [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+            [self.roktEventHandler setFulfillmentAttributesWithAttributes:attributes];
+        }];
     }
     if (self.eventManager != nil && self.eventManager.firstPositiveEngagement != nil) {
-        [self.eventManager.firstPositiveEngagement setFulfillmentAttributesWithAttributes:attributes];
+        [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+            [self.eventManager.firstPositiveEngagement setFulfillmentAttributesWithAttributes:attributes];
+        }];
     }
 }
 

--- a/Rokt.Widget/ios/RNRoktWidget.m
+++ b/Rokt.Widget/ios/RNRoktWidget.m
@@ -72,20 +72,23 @@ RCT_EXPORT_METHOD(execute:(NSString *)viewName
             nativePlaceholders[key] = view;
         }
         
-        RoktEventManager *event = [RoktEventManager allocWithZone: nil];
-        
+        self.eventManager = [RoktEventManager allocWithZone: nil];
+        [Rokt eventsWithViewName:viewName onEvent:^(RoktEvent * roktEvent) {
+            [self.eventManager onRoktEvents:roktEvent viewName:viewName];
+        }];
+
         [Rokt executeWithViewName:viewName attributes:finalAttributes
                        placements:nativePlaceholders
-                           onLoad:^{ [event onRoktCallbackReceived:@"onLoad"];}
+                           onLoad:^{ [self.eventManager onRoktCallbackReceived:@"onLoad"];}
                          onUnLoad:^{
-	    [event onRoktCallbackReceived:@"onUnLoad"];
+	    [self.eventManager onRoktCallbackReceived:@"onUnLoad"];
             RCTLogInfo(@"unloaded");
         }
-     onShouldShowLoadingIndicator:^{ [event onRoktCallbackReceived:@"onShouldShowLoadingIndicator"];}
-     onShouldHideLoadingIndicator:^{ [event onRoktCallbackReceived:@"onShouldHideLoadingIndicator"];}
+     onShouldShowLoadingIndicator:^{ [self.eventManager onRoktCallbackReceived:@"onShouldShowLoadingIndicator"];}
+     onShouldHideLoadingIndicator:^{ [self.eventManager onRoktCallbackReceived:@"onShouldHideLoadingIndicator"];}
              onEmbeddedSizeChange:^(NSString *selectedPlacement, CGFloat widgetHeight){
             
-            [event onWidgetHeightChanges:widgetHeight placement:selectedPlacement];
+            [self.eventManager onWidgetHeightChanges:widgetHeight placement:selectedPlacement];
             
         }];
         
@@ -116,27 +119,31 @@ RCT_EXPORT_METHOD(execute2Step:(NSString *)viewName
             nativePlaceholders[key] = view;
         }
         
-        RoktEventManager *event = [RoktEventManager allocWithZone: nil];
+        self.eventManager = [RoktEventManager allocWithZone: nil];
+
+        [Rokt eventsWithViewName:viewName onEvent:^(RoktEvent * roktEvent) {
+            [self.eventManager onRoktEvents:roktEvent viewName:viewName];
+        }];
         
         [Rokt execute2stepWithViewName:viewName attributes:finalAttributes
                             placements:nativePlaceholders
-                                onLoad:^{ [event onRoktCallbackReceived:@"onLoad"];}
+                                onLoad:^{ [self.eventManager onRoktCallbackReceived:@"onLoad"];}
                               onUnLoad:^{
-	    [event onRoktCallbackReceived:@"onUnLoad"];
+	    [self.eventManager onRoktCallbackReceived:@"onUnLoad"];
             RCTLogInfo(@"unloaded");
         }
-          onShouldShowLoadingIndicator:^{ [event onRoktCallbackReceived:@"onShouldShowLoadingIndicator"];}
-     onShouldHideLoadingIndicator:^{ [event onRoktCallbackReceived:@"onShouldHideLoadingIndicator"];}
+          onShouldShowLoadingIndicator:^{ [self.eventManager onRoktCallbackReceived:@"onShouldShowLoadingIndicator"];}
+     onShouldHideLoadingIndicator:^{ [self.eventManager onRoktCallbackReceived:@"onShouldHideLoadingIndicator"];}
                   onEmbeddedSizeChange:^(NSString *selectedPlacement, CGFloat widgetHeight){
             
-            [event onWidgetHeightChanges:widgetHeight placement:selectedPlacement];
+            [self.eventManager onWidgetHeightChanges:widgetHeight placement:selectedPlacement];
             
         }
                                onEvent:^(RoktEventType roktEventType, RoktEventHandler* roktEventHandler){
             self.roktEventHandler = roktEventHandler;
             if (roktEventType == RoktEventTypeFirstPositiveEngagement) {
                 RCTLogInfo(@"firstPositiveEvent was fired");
-                [event onFirstPositiveResponse];
+                [self.eventManager onFirstPositiveResponse];
             }
         }];
         
@@ -148,6 +155,9 @@ RCT_EXPORT_METHOD(setFulfillmentAttributes:(NSDictionary *)attributes) {
     if (self.roktEventHandler != nil) {
         RCTLogInfo(@"calling setFulfillmentAttributesWithAttributes");
         [self.roktEventHandler setFulfillmentAttributesWithAttributes:attributes];
+    }
+    if (self.eventManager != nil && self.eventManager.firstPositiveEngagement != nil) {
+        [self.eventManager.firstPositiveEngagement setFulfillmentAttributesWithAttributes:attributes];
     }
 }
 

--- a/Rokt.Widget/ios/RoktEventManager.h
+++ b/Rokt.Widget/ios/RoktEventManager.h
@@ -10,13 +10,14 @@
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
+#import <Rokt_Widget/Rokt_Widget-Swift.h>
 
 @interface RoktEventManager : RCTEventEmitter <RCTBridgeModule>
+@property (nonatomic) FirstPositiveEngagement * _Nullable firstPositiveEngagement;
 + (id)allocWithZone:(NSZone *)zone;
 - (void)onWidgetHeightChanges:(CGFloat)widgetHeight placement:(NSString*) selectedPlacement;
 - (void)onFirstPositiveResponse;
 - (void)onRoktCallbackReceived:(NSString*)eventValue;
-// TODO: Consume the method to propagate the events
-- (void)onRoktEvents:(NSString*)eventValue;
+- (void)onRoktEvents:(RoktEvent *)event viewName:(NSString *)viewName;
 
 @end

--- a/Rokt.Widget/ios/RoktEventManager.h
+++ b/Rokt.Widget/ios/RoktEventManager.h
@@ -16,5 +16,7 @@
 - (void)onWidgetHeightChanges:(CGFloat)widgetHeight placement:(NSString*) selectedPlacement;
 - (void)onFirstPositiveResponse;
 - (void)onRoktCallbackReceived:(NSString*)eventValue;
+// TODO: Consume the method to propagate the events
+- (void)onRoktEvents:(NSString*)eventValue;
 
 @end

--- a/Rokt.Widget/ios/RoktEventManager.m
+++ b/Rokt.Widget/ios/RoktEventManager.m
@@ -39,7 +39,7 @@ RCT_EXPORT_MODULE(RoktEventManager);
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[@"WidgetHeightChanges", @"FirstPositiveResponse", @"RoktCallback"];
+  return @[@"WidgetHeightChanges", @"FirstPositiveResponse", @"RoktCallback", @"RoktEvents"];
 }
 
 - (void)onWidgetHeightChanges:(CGFloat)widgetHeight placement:(NSString*) selectedPlacement
@@ -63,6 +63,14 @@ RCT_EXPORT_MODULE(RoktEventManager);
     if (hasListeners) {
         [self sendEventWithName:@"RoktCallback" body:@{@"callbackValue": eventValue}];
     }
+}
+
+- (void)onRoktEvents:(NSString*)eventValue
+{
+     if (hasListeners) {
+        // TODO: Implement events
+        [self sendEventWithName:@"RoktEvents" body:@{@"event": eventValue}];
+     }
 }
 
 @end

--- a/Rokt.Widget/ios/RoktEventManager.m
+++ b/Rokt.Widget/ios/RoktEventManager.m
@@ -9,6 +9,7 @@
 //  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
 
 #import "RoktEventManager.h"
+#import <Rokt_Widget/Rokt_Widget-Swift.h>
 
 @implementation RoktEventManager
 {
@@ -65,11 +66,47 @@ RCT_EXPORT_MODULE(RoktEventManager);
     }
 }
 
-- (void)onRoktEvents:(NSString*)eventValue
+- (void)onRoktEvents:(RoktEvent *)event viewName:(NSString *)viewName
 {
      if (hasListeners) {
-        // TODO: Implement events
-        [self sendEventWithName:@"RoktEvents" body:@{@"event": eventValue}];
+         NSString *placementId;
+         NSString *eventName;
+         if ([event isKindOfClass:[ShowLoadingIndicator class]]) {
+             eventName = @"ShowLoadingIndicator";
+         } else if ([event isKindOfClass:[HideLoadingIndicator class]]) {
+             eventName = @"HideLoadingIndicator";
+         } else if ([event isKindOfClass:[PlacementInteractive class]]) {
+             placementId = ((PlacementInteractive *)event).placementId;
+             eventName = @"PlacementInteractive";
+         } else if ([event isKindOfClass:[PlacementReady class]]) {
+             placementId = ((PlacementReady *)event).placementId;
+             eventName = @"PlacementReady";
+         } else if ([event isKindOfClass:[OfferEngagement class]]) {
+             placementId = ((OfferEngagement *)event).placementId;
+             eventName = @"OfferEngagement";
+         } else if ([event isKindOfClass:[PositiveEngagement class]]) {
+             placementId = ((PositiveEngagement *)event).placementId;
+             eventName = @"PositiveEngagement";
+         } else if ([event isKindOfClass:[PlacementClosed class]]) {
+             placementId = ((PlacementClosed *)event).placementId;
+             eventName = @"PlacementClosed";
+         } else if ([event isKindOfClass:[PlacementCompleted class]]) {
+             placementId = ((PlacementCompleted *)event).placementId;
+             eventName = @"PlacementCompleted";
+         } else if ([event isKindOfClass:[PlacementFailure class]]) {
+             placementId = ((PlacementFailure *)event).placementId;
+             eventName = @"PlacementFailure";
+         } else if ([event isKindOfClass:[FirstPositiveEngagement class]]) {
+             placementId = ((FirstPositiveEngagement *)event).placementId;
+             eventName = @"FirstPositiveEngagement";
+             self.firstPositiveEngagement = (FirstPositiveEngagement *)event;
+         }
+         NSMutableDictionary *payload = [@{@"event": eventName, @"viewName": viewName} mutableCopy];
+         if (placementId != nil) {
+             [payload setObject:placementId forKey:@"placementId"];
+         }
+
+         [self sendEventWithName:@"RoktEvents" body:payload];
      }
 }
 

--- a/Rokt.Widget/rokt-react-native-sdk.podspec
+++ b/Rokt.Widget/rokt-react-native-sdk.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   
 
   s.dependency "React"
-  s.dependency "Rokt-Widget", "~> 4.2.0"
+  s.dependency "Rokt-Widget", "~> 4.3.0-alpha.1"
 end

--- a/RoktSampleApp/App.js
+++ b/RoktSampleApp/App.js
@@ -76,13 +76,24 @@ export default class App extends Component {
       Rokt.setFulfillmentAttributes(FULLFILLMENT_ATTRIBUTES);
     },
   );
-   
+
   callBackSubscription = eventManagerEmitter.addListener(
     'RoktCallback',
     (data) => {
       console.log('roktCallback received: ' + data.callbackValue);
     },
   );
+
+  eventSubscription = eventManagerEmitter.addListener('RoktEvents', (data) => {
+    switch (data.event) {
+      case 'ShowLoadingIndicator':
+        console.log('Received ShowLoadingIndicator');
+        break;
+      default:
+        console.log('Some event received ' + data.event);
+        break;
+    }
+  });
 
   encrypt(text, publicKey) {
     var publicBytes = forge.util.decode64(publicKey);

--- a/RoktSampleApp/App.js
+++ b/RoktSampleApp/App.js
@@ -85,14 +85,7 @@ export default class App extends Component {
   );
 
   eventSubscription = eventManagerEmitter.addListener('RoktEvents', (data) => {
-    switch (data.event) {
-      case 'ShowLoadingIndicator':
-        console.log('Received ShowLoadingIndicator');
-        break;
-      default:
-        console.log('Some event received ' + data.event);
-        break;
-    }
+    console.log(`*** ROKT EVENT *** ${JSON.stringify(data)}`);
   });
 
   encrypt(text, publicKey) {

--- a/RoktSampleApp/ios/Podfile.lock
+++ b/RoktSampleApp/ios/Podfile.lock
@@ -351,13 +351,13 @@ PODS:
     - React-jsi (= 0.69.12)
     - React-logger (= 0.69.12)
     - React-perflogger (= 0.69.12)
-  - RNCCheckbox (0.5.16):
+  - RNCCheckbox (0.5.17):
     - BEMCheckBox (~> 1.4)
     - React-Core
   - rokt-react-native-sdk (4.2.0):
     - React
-    - Rokt-Widget (~> 4.2.0)
-  - Rokt-Widget (4.2.0)
+    - Rokt-Widget (~> 4.3.0-alpha.1)
+  - Rokt-Widget (4.3.0-alpha.1)
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -558,9 +558,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: c9cd9f21bbcb3b9c6deedbb66f13e373f57dd795
   React-runtimeexecutor: ea78653fbc68bd6f2d3f5e7e311bc5a9dc8bfeca
   ReactCommon: f4bb9e5209ea5c3c6ab25e100895119e58d6e50a
-  RNCCheckbox: 75255b03e604bbcc26411eb31c4cbe3e3865f538
-  rokt-react-native-sdk: 8d09d50ed60a2e82f8945ed6ce76d76d0dde70b9
-  Rokt-Widget: cb1623a572507cdefc957a4e8174e73f888f4c36
+  RNCCheckbox: a3ca9978cb0846b981d28da4e9914bd437403d77
+  rokt-react-native-sdk: efd320edf3ed0e3958d1938251d646349f4c5880
+  Rokt-Widget: bbc79d7dd807902f403928cc88d125f003534235
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8a90b50af67eaa9fe94fd03e550bfeab06096873
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a


### PR DESCRIPTION
### Background ###

* Subscribe to the events api and send them to RN events channel
* Use the Activity lifecycleScope for collecting the flow.

Fixes [MP-3269](https://rokt.atlassian.net/browse/MP-3269)

### What Has Changed: ###

Implemented the events API

### How Has This Been Tested? ###

Tested locally
![Screenshot 2024-04-19 at 1 19 02 PM](https://github.com/ROKT/rokt-sdk-react-native/assets/125323226/5f9b99a0-1067-4850-8f29-ca949484e28a)
![Screenshot 2024-04-19 at 1 20 45 PM](https://github.com/ROKT/rokt-sdk-react-native/assets/125323226/d457db27-edc0-4378-940d-d2ba9bb1b262)

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.