### PR TITLE
MP-3481 - Fix the issue when init was called before activity resume

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,6 +104,7 @@ steps:
           download: "Rokt.Widget/*.tgz"
     agents:
       queue: ${MAC_BK_AGENT}
+      "aws:instance-id": i-0daacd0bb27950615
     timeout_in_minutes: 45
 
   - block: ":whale: Publish Alpha Version to npm"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,7 +104,6 @@ steps:
           download: "Rokt.Widget/*.tgz"
     agents:
       queue: ${MAC_BK_AGENT}
-      "aws:instance-id": i-0daacd0bb27950615
     timeout_in_minutes: 45
 
   - block: ":whale: Publish Alpha Version to npm"

--- a/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetModule.kt
+++ b/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetModule.kt
@@ -1,5 +1,7 @@
 package com.rokt.reactnativesdk
 
+import android.app.Activity
+import android.os.Handler
 import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -44,23 +46,15 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
 
     @ReactMethod
     fun initialize(roktTagId: String?, appVersion: String?) {
-        val currentActivity = currentActivity
-        if (currentActivity != null && appVersion != null && roktTagId != null) {
-            Rokt.setFrameworkType(ReactNative)
-            Rokt.init(roktTagId, appVersion, currentActivity)
-        } else {
-            logDebug("Activity, roktTagId and AppVersion cannot be null")
+        initRokt(roktTagId, appVersion) { activity ->
+            Rokt.init(requireNotNull(roktTagId), requireNotNull(appVersion), activity)
         }
     }
 
     @ReactMethod
     fun initializeWithFontFiles(roktTagId: String?, appVersion: String?, fontsMap: ReadableMap?) {
-        val currentActivity = currentActivity
-        if (currentActivity != null && appVersion != null && roktTagId != null) {
-            Rokt.setFrameworkType(ReactNative)
-            Rokt.init(roktTagId, appVersion, currentActivity, HashSet(), readableMapToMapOfStrings(fontsMap))
-        } else {
-            logDebug("Activity, roktTagId and AppVersion cannot be null")
+        initRokt(roktTagId, appVersion) { activity ->
+            Rokt.init(requireNotNull(roktTagId), requireNotNull(appVersion), activity, HashSet(), readableMapToMapOfStrings(fontsMap))
         }
     }
 
@@ -111,6 +105,23 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
         }
     }
 
+    private fun initRokt(roktTagId: String?, appVersion: String?, init: (activity: Activity) -> Unit) {
+        if (roktTagId == null || appVersion == null) {
+            logDebug("roktTagId and appVersion cannot be null")
+            return
+        }
+        Rokt.setFrameworkType(ReactNative)
+        if (currentActivity == null) {
+            // When the init was called from ReactComponent init and the activity is not fully resumed,
+            // the currentActivity could be null.
+            // Add a delay in this scenario and call the init
+            Handler(reactContext.mainLooper).postDelayed({
+                currentActivity?.let(init) ?: logDebug("Failed to initialize Rokt. Activity is null!!")
+            }, 500)
+        } else {
+            currentActivity?.let(init)
+        }
+    }
 
     private fun sendEvent(
         reactContext: ReactContext?,


### PR DESCRIPTION
### Background ###

When the Activity is starting up, the React component initialization can happen before the activity resume. In this scenario the currentActivity provided by RN framework would be null.
* When the currentActivity is null, add a delay in calling the Rokt SDK init

Fixes [MP-3481](https://rokt.atlassian.net/browse/MP-3481)

### What Has Changed: ###

Fix for the init failure scenario.

### How Has This Been Tested? ###

Tested locally by creating RN release apk

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.