### PR TITLE
[CI-92] Rokt Config Wrapper

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,7 +42,6 @@ steps:
       - npm install
       - mkdir android/app/src/main/assets/ && npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle
       - cd android
-      - gem install fastlane
       - bundle install
       - bundle exec fastlane deviceFarmUITest
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -120,7 +120,6 @@ steps:
       - cd - && cd RoktSampleApp
       - npm install
       - cd android
-      - gem install fastlane
       - bundle install
       - bundle exec fastlane publishAlphaSDK
     plugins:
@@ -156,7 +155,6 @@ steps:
       - cd - && cd RoktSampleApp
       - npm install
       - cd android
-      - gem install fastlane
       - bundle install
       - bundle exec fastlane publishSDK
     plugins:

--- a/.buildkite/release.pipeline.yml
+++ b/.buildkite/release.pipeline.yml
@@ -45,7 +45,6 @@ steps:
       - npm install
       - mkdir android/app/src/main/assets/ && npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle
       - cd android
-      - gem install fastlane
       - bundle install
       - bundle exec fastlane deviceFarmUITest
     plugins:
@@ -122,7 +121,6 @@ steps:
       - cd - && cd RoktSampleApp
       - npm install
       - cd android
-      - gem install fastlane
       - bundle install
       - bundle exec fastlane automatedPublish dist_tag:$(../../.buildkite/bin/extract_dist_tag.sh $(buildkite-agent meta-data get VERSION))
     plugins:

--- a/Rokt.Widget/src/Rokt.tsx
+++ b/Rokt.Widget/src/Rokt.tsx
@@ -13,12 +13,12 @@ export abstract class Rokt {
         }
     }
 
-    public static execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>): void {
-        RNRoktWidget.execute(viewName, attributes, placeholders);
+    public static execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: RoktConfig): void {
+        RNRoktWidget.execute(viewName, attributes, placeholders, roktConfig);
     }
 
-    public static execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>): void {
-        RNRoktWidget.execute2Step(viewName, attributes, placeholders);
+    public static execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: RoktConfig): void {
+        RNRoktWidget.execute2Step(viewName, attributes, placeholders, roktConfig);
     }
 
     public static setFulfillmentAttributes(attributes: Record<string, string>): void {
@@ -50,10 +50,38 @@ interface RNRoktWidget {
     initialize(roktTagId: string, appVersion: string): void;
     initializeWithFonts(roktTagId: string, appVersion: string, fontPostScriptNames?: string[]): void;
     initializeWithFontFiles(roktTagId: string, appVersion: string, fontsMap?: Record<string, string>): void;
-    execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>): void;
-    execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>): void;
+    execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: RoktConfig): void;
+    execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: RoktConfig): void;
     setFulfillmentAttributes(attributes: Record<string, string>): void;
     setEnvironmentToStage(): void;
     setEnvironmentToProd(): void;
     setLoggingEnabled(enabled: boolean): void;
+}
+
+export interface IRoktConfig {
+    readonly colorMode?: ColorMode;
+}
+
+class RoktConfig implements IRoktConfig {
+    constructor(roktConfig: RoktConfig) {
+        Object.assign(this, roktConfig);
+    }
+}
+
+export class RoktConfigBuilder implements Partial<IRoktConfig> {
+    readonly colorMode?: ColorMode;
+
+    public withColorMode(value: ColorMode): this & Pick<IRoktConfig, 'colorMode'> {
+        return Object.assign(this, {colorMode: value})
+    }
+
+    public build(this: IRoktConfig) {
+        return new RoktConfig(this);
+    }
+}
+
+export enum ColorMode {
+    LIGHT = "LIGHT",
+    DARK = "DARK",
+    SYSTEM = "SYSTEM"
 }

--- a/Rokt.Widget/src/Rokt.tsx
+++ b/Rokt.Widget/src/Rokt.tsx
@@ -15,7 +15,7 @@ export abstract class Rokt {
 
     public static execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: IRoktConfig): void {
         if (roktConfig) {
-            ; // TODO implement
+            return // TODO implement
         } else {
             RNRoktWidget.execute(viewName, attributes, placeholders);
         }
@@ -23,7 +23,7 @@ export abstract class Rokt {
 
     public static execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: IRoktConfig): void {
         if (roktConfig) {
-            ; // TODO implement
+            return // TODO implement
         } else {
             RNRoktWidget.execute2Step(viewName, attributes, placeholders);
         }

--- a/Rokt.Widget/src/Rokt.tsx
+++ b/Rokt.Widget/src/Rokt.tsx
@@ -89,7 +89,7 @@ export class RoktConfigBuilder implements Partial<IRoktConfig> {
 }
 
 export enum ColorMode {
-    LIGHT = "LIGHT",
-    DARK = "DARK",
-    SYSTEM = "SYSTEM"
+    Light = "LIGHT",
+    Dark = "DARK",
+    System = "SYSTEM"
 }

--- a/Rokt.Widget/src/Rokt.tsx
+++ b/Rokt.Widget/src/Rokt.tsx
@@ -88,8 +88,4 @@ export class RoktConfigBuilder implements Partial<IRoktConfig> {
     }
 }
 
-export enum ColorMode {
-    Light = "LIGHT",
-    Dark = "DARK",
-    System = "SYSTEM"
-}
+export type ColorMode = "light" | "dark" | "system"

--- a/Rokt.Widget/src/Rokt.tsx
+++ b/Rokt.Widget/src/Rokt.tsx
@@ -13,12 +13,20 @@ export abstract class Rokt {
         }
     }
 
-    public static execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: RoktConfig): void {
-        RNRoktWidget.execute(viewName, attributes, placeholders, roktConfig);
+    public static execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: IRoktConfig): void {
+        if (roktConfig) {
+            ; // TODO implement
+        } else {
+            RNRoktWidget.execute(viewName, attributes, placeholders);
+        }
     }
 
-    public static execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: RoktConfig): void {
-        RNRoktWidget.execute2Step(viewName, attributes, placeholders, roktConfig);
+    public static execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: IRoktConfig): void {
+        if (roktConfig) {
+            ; // TODO implement
+        } else {
+            RNRoktWidget.execute2Step(viewName, attributes, placeholders);
+        }
     }
 
     public static setFulfillmentAttributes(attributes: Record<string, string>): void {
@@ -50,8 +58,8 @@ interface RNRoktWidget {
     initialize(roktTagId: string, appVersion: string): void;
     initializeWithFonts(roktTagId: string, appVersion: string, fontPostScriptNames?: string[]): void;
     initializeWithFontFiles(roktTagId: string, appVersion: string, fontsMap?: Record<string, string>): void;
-    execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: RoktConfig): void;
-    execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: RoktConfig): void;
+    execute(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: IRoktConfig): void;
+    execute2Step(viewName: string, attributes: Record<string, string>, placeholders: Record<string, number | null>, roktConfig?: IRoktConfig): void;
     setFulfillmentAttributes(attributes: Record<string, string>): void;
     setEnvironmentToStage(): void;
     setEnvironmentToProd(): void;

--- a/Rokt.Widget/src/index.tsx
+++ b/Rokt.Widget/src/index.tsx
@@ -5,5 +5,5 @@ import { Rokt, IRoktConfig, RoktConfigBuilder, ColorMode } from './Rokt'
 
 const { RoktEventManager } = NativeModules;
 
-export {RoktEmbeddedView, Rokt, RoktEventManager, RoktConfigBuilder, ColorMode};
-export type {IRoktConfig};
+export {RoktEmbeddedView, Rokt, RoktEventManager, RoktConfigBuilder};
+export type {IRoktConfig, ColorMode};

--- a/Rokt.Widget/src/index.tsx
+++ b/Rokt.Widget/src/index.tsx
@@ -1,8 +1,9 @@
 import 'react-native'
 import { NativeModules } from 'react-native';
 import { RoktEmbeddedView } from './rokt-embedded-view'
-import { Rokt } from './Rokt'
+import { Rokt, IRoktConfig, RoktConfigBuilder, ColorMode } from './Rokt'
 
 const { RoktEventManager } = NativeModules;
 
-export {RoktEmbeddedView, Rokt, RoktEventManager};
+export {RoktEmbeddedView, Rokt, RoktEventManager, RoktConfigBuilder, ColorMode};
+export type {IRoktConfig};


### PR DESCRIPTION
### Background ###

Creating Typescript builder class for RoktConfig. Only dealing with the wrapper side in this PR, will wire up to native modules next into workstation branch.

Fixes [CI-92](https://rokt.atlassian.net/browse/CI-92)

### What Has Changed: ###

- Added `RoktConfigBuilder`: used like `new RoktConfigBuilder().withColorMode(ColorMode.Dark).build()`

### How Has This Been Tested? ###

Tested in tsx file

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.