### PR TITLE
LAYOUT-1313 - Fix Expo plugin and support kotlin

### DIFF
--- a/Rokt.Widget/android/build.gradle
+++ b/Rokt.Widget/android/build.gradle
@@ -59,6 +59,5 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
-    implementation ('com.rokt:roktsdk:4.4.0-alpha1')
+    implementation ('com.rokt:roktsdk:4.5.1')
 }
-  


### PR DESCRIPTION
### Background ###

New Expo version templates are in kotlin.
Support kotlin MainApplication file in the Expo plugin and add the `RoktEmbeddedViewPackage` in the package registry.

Fixes [LAYOUT-1313](https://rokt.atlassian.net/browse/LAYOUT-1313)

### What Has Changed: ###

Fix the Expo plugin and make it compatible with the latest version

### How Has This Been Tested? ###

Tested locally with Expo 52(kotlin) and Expo 46(java)

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.