### PR TITLE
LAYOUT-1330 - Implement Init complete event in ReactNative wrapper

### DIFF
--- a/Rokt.Widget/android/build.gradle
+++ b/Rokt.Widget/android/build.gradle
@@ -59,5 +59,5 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
-    implementation ('com.rokt:roktsdk:4.5.1')
+    implementation ('com.rokt:roktsdk:4.5.2-alpha.2')
 }

--- a/Rokt.Widget/ios/RNRoktWidget.m
+++ b/Rokt.Widget/ios/RNRoktWidget.m
@@ -36,6 +36,7 @@ RCT_EXPORT_METHOD(initialize:(NSString *)roktTagId appVersion: (NSString * _Null
         RCTLog(@"roktTagId cannot be null");
         return;
     }
+    [self subscribeGlobalEvents];
     [Rokt initWithRoktTagId:roktTagId];
 }
 
@@ -45,6 +46,7 @@ RCT_EXPORT_METHOD(initializeWithFonts:(NSString *)roktTagId appVersion: (NSStrin
         RCTLog(@"roktTagId cannot be null");
         return;
     }
+    [self subscribeGlobalEvents];
     [Rokt initWithRoktTagId:roktTagId];
 }
 
@@ -71,11 +73,8 @@ RCT_EXPORT_METHOD(execute:(NSString *)viewName
             
             nativePlaceholders[key] = view;
         }
-        
-        self.eventManager = [RoktEventManager allocWithZone: nil];
-        [Rokt eventsWithViewName:viewName onEvent:^(RoktEvent * roktEvent) {
-            [self.eventManager onRoktEvents:roktEvent viewName:viewName];
-        }];
+
+        [self subscribeViewEvents:viewName];
 
         [Rokt executeWithViewName:viewName attributes:finalAttributes
                        placements:nativePlaceholders
@@ -124,10 +123,7 @@ RCT_EXPORT_METHOD(executeWithConfig:(NSString *)viewName
             nativePlaceholders[key] = view;
         }
         
-        self.eventManager = [RoktEventManager allocWithZone: nil];
-        [Rokt eventsWithViewName:viewName onEvent:^(RoktEvent * roktEvent) {
-            [self.eventManager onRoktEvents:roktEvent viewName:viewName];
-        }];
+        [self subscribeViewEvents:viewName];
 
         [Rokt executeWithViewName:viewName attributes:finalAttributes
                        placements:nativePlaceholders
@@ -172,11 +168,7 @@ RCT_EXPORT_METHOD(execute2Step:(NSString *)viewName
             nativePlaceholders[key] = view;
         }
         
-        self.eventManager = [RoktEventManager allocWithZone: nil];
-
-        [Rokt eventsWithViewName:viewName onEvent:^(RoktEvent * roktEvent) {
-            [self.eventManager onRoktEvents:roktEvent viewName:viewName];
-        }];
+        [self subscribeViewEvents:viewName];
         
         [Rokt execute2stepWithViewName:viewName attributes:finalAttributes
                             placements:nativePlaceholders
@@ -318,6 +310,24 @@ RCT_EXPORT_METHOD(setFulfillmentAttributes:(NSDictionary *)attributes) {
         [builder colorMode:value];
     }
     return [builder build];
+}
+
+- (void)subscribeGlobalEvents
+{
+    self.eventManager = [RoktEventManager allocWithZone: nil];
+    [Rokt globalEventsOnEvent:^(RoktEvent * _Nonnull roktEvent) {
+        [self.eventManager onRoktEvents:roktEvent viewName:nil];
+    }];
+}
+
+- (void)subscribeViewEvents:(NSString* _Nonnull) viewName
+{
+    if (self.eventManager == nil) {
+        self.eventManager = [RoktEventManager allocWithZone: nil];
+    }
+    [Rokt eventsWithViewName:viewName onEvent:^(RoktEvent * _Nonnull roktEvent) {
+        [self.eventManager onRoktEvents:roktEvent viewName:viewName];
+    }];
 }
 
 RCT_EXPORT_METHOD(setEnvironmentToStage) {

--- a/Rokt.Widget/ios/RoktEventManager.h
+++ b/Rokt.Widget/ios/RoktEventManager.h
@@ -18,6 +18,6 @@
 - (void)onWidgetHeightChanges:(CGFloat)widgetHeight placement:(NSString*) selectedPlacement;
 - (void)onFirstPositiveResponse;
 - (void)onRoktCallbackReceived:(NSString*)eventValue;
-- (void)onRoktEvents:(RoktEvent *)event viewName:(NSString *)viewName;
+- (void)onRoktEvents:(RoktEvent * _Nonnull)event viewName:(NSString * _Nullable)viewName;
 
 @end

--- a/Rokt.Widget/ios/RoktEventManager.m
+++ b/Rokt.Widget/ios/RoktEventManager.m
@@ -66,11 +66,12 @@ RCT_EXPORT_MODULE(RoktEventManager);
     }
 }
 
-- (void)onRoktEvents:(RoktEvent *)event viewName:(NSString *)viewName
+- (void)onRoktEvents:(RoktEvent * _Nonnull)event viewName:(NSString * _Nullable)viewName
 {
      if (hasListeners) {
          NSString *placementId;
-         NSString *eventName;
+         NSString *eventName = @"";
+         NSString *status;
          if ([event isKindOfClass:[ShowLoadingIndicator class]]) {
              eventName = @"ShowLoadingIndicator";
          } else if ([event isKindOfClass:[HideLoadingIndicator class]]) {
@@ -100,10 +101,19 @@ RCT_EXPORT_MODULE(RoktEventManager);
              placementId = ((FirstPositiveEngagement *)event).placementId;
              eventName = @"FirstPositiveEngagement";
              self.firstPositiveEngagement = (FirstPositiveEngagement *)event;
+         } else if ([event isKindOfClass:[InitComplete class]]) {
+             eventName = @"InitComplete";
+             status = ((InitComplete *)event).success ? @"true" : @"false";
          }
-         NSMutableDictionary *payload = [@{@"event": eventName, @"viewName": viewName} mutableCopy];
+         NSMutableDictionary *payload = [@{@"event": eventName} mutableCopy];
+         if (viewName != nil) {
+             [payload setObject:viewName forKey:@"viewName"];
+         }
          if (placementId != nil) {
              [payload setObject:placementId forKey:@"placementId"];
+         }
+         if (status != nil) {
+             [payload setObject:status forKey:@"status"];
          }
 
          [self sendEventWithName:@"RoktEvents" body:payload];

--- a/Rokt.Widget/package-lock.json
+++ b/Rokt.Widget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rokt/react-native-sdk",
-  "version": "4.4.0",
+  "version": "4.5.2-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rokt/react-native-sdk",
-      "version": "4.4.0",
+      "version": "4.5.2-alpha.2",
       "license": "Copyright 2020 Rokt Pte Ltd",
       "dependencies": {
         "@expo/config-plugins": "^7.2.5"

--- a/Rokt.Widget/package.json
+++ b/Rokt.Widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rokt/react-native-sdk",
-  "version": "4.4.0",
+  "version": "4.5.2-alpha.2",
   "description": "Rokt Mobile SDK to integrate ROKT Api into ReactNative application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/Rokt.Widget/rokt-react-native-sdk.podspec
+++ b/Rokt.Widget/rokt-react-native-sdk.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   
 
   s.dependency "React"
-  s.dependency "Rokt-Widget", "~> 4.4.0"
+  s.dependency "Rokt-Widget", "~> 4.5.2-alpha.3"
 end

--- a/RoktSampleApp/ios/Podfile.lock
+++ b/RoktSampleApp/ios/Podfile.lock
@@ -351,13 +351,13 @@ PODS:
     - React-jsi (= 0.69.12)
     - React-logger (= 0.69.12)
     - React-perflogger (= 0.69.12)
-  - RNCCheckbox (0.5.16):
+  - RNCCheckbox (0.5.17):
     - BEMCheckBox (~> 1.4)
     - React-Core
-  - rokt-react-native-sdk (4.4.0):
+  - rokt-react-native-sdk (4.5.2-alpha.2):
     - React
-    - Rokt-Widget (~> 4.4.0)
-  - Rokt-Widget (4.4.0)
+    - Rokt-Widget (~> 4.5.2-alpha.3)
+  - Rokt-Widget (4.5.2-alpha.3)
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -558,9 +558,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: c9cd9f21bbcb3b9c6deedbb66f13e373f57dd795
   React-runtimeexecutor: ea78653fbc68bd6f2d3f5e7e311bc5a9dc8bfeca
   ReactCommon: f4bb9e5209ea5c3c6ab25e100895119e58d6e50a
-  RNCCheckbox: 75255b03e604bbcc26411eb31c4cbe3e3865f538
-  rokt-react-native-sdk: fb3d44227c9ad4fd2b51ab25e5676cc56135b790
-  Rokt-Widget: 8f0d8f8bbc4d6f433f377352828cfeeffacb4e07
+  RNCCheckbox: a3ca9978cb0846b981d28da4e9914bd437403d77
+  rokt-react-native-sdk: d5241b8ab3202106bb69bf37bbd5c857a4882ac6
+  Rokt-Widget: 77acf3a8a73edd5a0a257721d7b615192ec8f278
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8a90b50af67eaa9fe94fd03e550bfeab06096873
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/RoktSampleApp/package.json
+++ b/RoktSampleApp/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@react-native-community/checkbox": "^0.5.12",
-    "@rokt/react-native-sdk": "file:../Rokt.Widget/rokt-react-native-sdk-4.4.0.tgz",
+    "@rokt/react-native-sdk": "file:../Rokt.Widget/rokt-react-native-sdk-4.5.2-alpha.2.tgz",
     "crypto-js": "^4.0.0",
     "node-forge": "^1.3.1",
     "react": "18.0.0",


### PR DESCRIPTION
### Background ###

Listen for global SDK events in native Android and iOS wrappers Propagate events in `RoktEvents` stream

Fixes [LAYOUT-1330](https://rokt.atlassian.net/browse/LAYOUT-1330)

### What Has Changed: ###

Init complete event

### How Has This Been Tested? ###

Tested locally

Android

https://github.com/user-attachments/assets/c8718351-ed8f-42a0-b04f-c4a7ae0cd310

iOS

https://github.com/user-attachments/assets/0cae37ea-7225-4987-afce-15b98f0728a7

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.