### PR TITLE
NoJira - Fix the version conflict issue

### DIFF
--- a/RoktSampleApp/android/app/build.gradle
+++ b/RoktSampleApp/android/app/build.gradle
@@ -180,6 +180,16 @@ dependencies {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        eachDependency {
+            if (requested.group == "androidx.lifecycle" && requested.name == "lifecycle-livedata-core") {
+                useVersion("2.5.1")
+            }
+        }
+    }
+}
+
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {


### PR DESCRIPTION

### Background ###

Since the Example app is using an old AGP plugin it is failing in D8 step for lifecycle-livedata-core.
Force the app to use 2.5.1

Error with version `2.8.3`
```
/lifecycle-livedata-core-2.8.3-runtime.jar: D8: java.lang.NullPointerException

FAILURE: Build failed with an exception.

What went wrong:
Execution failed for task ':app:mergeExtDexDebug'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Failed to transform lifecycle-livedata-core-2.8.3.aar (androidx.lifecycle:lifecycle-livedata-core:2.8.3) to match attributes {artifactType=android-dex, asm-transformed-variant=NONE, dexing-enable-desugaring=true, dexing-incremental-transform=true, dexing-is-debuggable=true, dexing-min-sdk=21, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
```

### What Has Changed: ###

List out what has changed as a result of this PR.

### How Has This Been Tested? ###

Describe the tests that you ran to verify your changes. 

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.