### PR TITLE
NoJira - update xcframework header file

### DIFF
--- a/Rokt.Widget/ios/RoktWidgetManager.m
+++ b/Rokt.Widget/ios/RoktWidgetManager.m
@@ -11,7 +11,7 @@
 
 #import <Foundation/Foundation.h>
 #import <React/RCTViewManager.h>
-#import <Rokt_Widget/Rokt-Widget-umbrella.h>
+#import <Rokt_Widget/Rokt_Widget-Swift.h>
 
 @interface RoktNativeWidgetManager : RCTViewManager
 @end

--- a/Rokt.Widget/package-lock.json
+++ b/Rokt.Widget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rokt/react-native-sdk",
-  "version": "4.6.0",
+  "version": "4.7.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rokt/react-native-sdk",
-      "version": "4.6.0",
+      "version": "4.7.0-alpha.1",
       "license": "Copyright 2020 Rokt Pte Ltd",
       "dependencies": {
         "@expo/config-plugins": "^7.2.5"

--- a/Rokt.Widget/package.json
+++ b/Rokt.Widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rokt/react-native-sdk",
-  "version": "4.6.0",
+  "version": "4.7.0-alpha.1",
   "description": "Rokt Mobile SDK to integrate ROKT Api into ReactNative application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/Rokt.Widget/rokt-react-native-sdk.podspec
+++ b/Rokt.Widget/rokt-react-native-sdk.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   
 
   s.dependency "React"
-  s.dependency "Rokt-Widget", "~> 4.5.2-alpha.3"
+  s.dependency "Rokt-Widget", "~> 4.7.0-alpha.1"
 end

--- a/RoktSampleApp/README.md
+++ b/RoktSampleApp/README.md
@@ -27,7 +27,8 @@ The CI system used is  **Buildkite**  [https://buildkite.com/rokt/react-native-s
 ### NPM install on Sample app
 1. Go to *RoktSampleApp* directory
 2. `npm install`
-3. If installation errors on Rokt.Widget/rokt-react-native-sdk-X.X.X.tgz not found (where X.X.X is the Rokt SDK version), follow [README on *Rokt.Widget* directory](https://github.com/ROKT/rokt-sdk-react-native/tree/release-3.10.x/Rokt.Widget#readme) first
+
+To clear the cache, delete `node_modules` and `package.json` and re-run `npm install`
 
 ### Start with npx
 Make sure you have your Android device or Emulator turned on.
@@ -37,7 +38,8 @@ go to *RoktSampleApp* directory and run `npx react-native start --reset-cache`
 ## iOS
 
 ### Install the pod
-go to *RoktSampleApp/ios* directory and run `pod install` (if pod install failed, run `pod update` to get the latest libraries)
+go to *RoktSampleApp/ios* directory and run `bundle exec pod install --repo-update` 
+if pod install failed from rokt-react-native-sdk podfile, run `bundle exec pod update Rokt-Widget`
 
 ## Run iOS
 Make sure you have your iOS device or Simulator turned on.
@@ -52,12 +54,15 @@ Make sure you have your iOS device or Simulator turned on.
 go to *RoktSampleApp* directory and run `npx react-native run-android` 
 
 ## Note
-To test the SDK changes locally follow the below steps:
-1. Create a package in SDK with a new version. 
-2. Go to RoktSampleApp root, modify the ```package.json``` of RoktSampleApp.
-3. Delete the ```package-lock.json``` and run the ```npm install``` again.
-4. For iOS, go to ios directory and run ``` pod install ```.
+To test the SDK changes locally
 
+### Create a package in SDK with a new version. 
+1. Go to *Rokt.Widget* directory
+2. change the version ```X.X.X``` in ```package.json``` to a new version. 
+3. `npm install`
+4. `npm run build` to build the `dist` folder
+5. `npm pack` to build the new ```rokt-react-native-sdk-X.X.X.tgz```
+6. go to `RoktSampleApp` project ```package.json``` to point to ```rokt-react-native-sdk-X.X.X.tgz``` file
 
 # Copyright
 Copyright 2020 Rokt Pte Ltd Licensed under the Rokt Software Development Kit (SDK) Terms of Use Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/

--- a/RoktSampleApp/ios/Podfile.lock
+++ b/RoktSampleApp/ios/Podfile.lock
@@ -354,10 +354,10 @@ PODS:
   - RNCCheckbox (0.5.16):
     - BEMCheckBox (~> 1.4)
     - React-Core
-  - rokt-react-native-sdk (4.6.0):
+  - rokt-react-native-sdk (4.7.0-alpha.1):
     - React
-    - Rokt-Widget (~> 4.5.2-alpha.3)
-  - Rokt-Widget (4.5.2-alpha.3)
+    - Rokt-Widget (~> 4.7.0-alpha.1)
+  - Rokt-Widget (4.7.0-alpha.1)
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -559,8 +559,8 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: ea78653fbc68bd6f2d3f5e7e311bc5a9dc8bfeca
   ReactCommon: f4bb9e5209ea5c3c6ab25e100895119e58d6e50a
   RNCCheckbox: 75255b03e604bbcc26411eb31c4cbe3e3865f538
-  rokt-react-native-sdk: ca25fb7638c520435dd883cde9a55b5e49c270b1
-  Rokt-Widget: 77acf3a8a73edd5a0a257721d7b615192ec8f278
+  rokt-react-native-sdk: 81799fbf43ce1d34e4e9fdd92dbdfa692d71ef93
+  Rokt-Widget: e7cc3037d07569af2e74b556e68e6272494367a7
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8a90b50af67eaa9fe94fd03e550bfeab06096873
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/RoktSampleApp/package.json
+++ b/RoktSampleApp/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@react-native-community/checkbox": "^0.5.12",
-    "@rokt/react-native-sdk": "file:../Rokt.Widget/rokt-react-native-sdk-4.6.0.tgz",
+    "@rokt/react-native-sdk": "file:../Rokt.Widget/rokt-react-native-sdk-4.7.0-alpha.1.tgz",
     "crypto-js": "^4.0.0",
     "node-forge": "^1.3.1",
     "react": "18.0.0",


### PR DESCRIPTION
### Background ###

with cocoapods we generate a umbrella header `Rokt-Widget-umbrella.h` in the module map, with version 4.7, we now generate a new umbrella header `Rokt_Widget-Swift.h`.

Hence we have to update the header name.


cocoapods module map file `Example/Pods/Target Support Files/Rokt-Widget/Rokt-Widget.modulemap`:
```
framework module Rokt_Widget {
  umbrella header "Rokt-Widget-umbrella.h"

  export *
  module * { export * }
}
```

Fixes [([issue](https://rokt.atlassian.net/browse/NI-360))]

### What Has Changed: ###


- update umbrella header name
- update version to 4.7

### How Has This Been Tested? ###

Describe the tests that you ran to verify your changes. 

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.