### PR TITLE
LAYOUT-1641 - Add caching API support in ReactNative SDK

### DIFF
--- a/Rokt.Widget/android/build.gradle
+++ b/Rokt.Widget/android/build.gradle
@@ -59,5 +59,5 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
-    implementation ('com.rokt:roktsdk:4.5.2-alpha.2')
+    implementation ('com.rokt:roktsdk:4.7.0-alpha.3')
 }

--- a/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetModule.kt
+++ b/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetModule.kt
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import com.facebook.react.uimanager.NativeViewHierarchyManager
 import com.facebook.react.uimanager.UIManagerModule
+import com.rokt.roktsdk.CacheConfig
 import com.rokt.roktsdk.FulfillmentAttributes
 import com.rokt.roktsdk.Rokt
 import com.rokt.roktsdk.RoktConfig
@@ -321,8 +322,28 @@ class RNRoktWidgetModule internal constructor(private val reactContext: ReactApp
         configMap["colorMode"]?.let {
             builder.colorMode(it.toColorMode())
         }
-
+        roktConfig?.getMap("cacheConfig")?.let {
+            builder.cacheConfig(buildCacheConfig(it))
+        }
         return builder.build()
+    }
+
+    private fun buildCacheConfig(cacheConfigMap: ReadableMap?): CacheConfig {
+        val cacheDurationInSeconds =
+            if (cacheConfigMap?.hasKey("cacheDurationInSeconds") == true) {
+                cacheConfigMap.getDouble("cacheDurationInSeconds").toLong()
+            } else {
+                0L
+            }
+        val cacheAttributes = if (cacheConfigMap?.hasKey("cacheAttributes") == true) {
+            cacheConfigMap.getMap("cacheAttributes")?.toHashMap()?.mapValues { it.value as String }
+        } else {
+            null
+        }
+        return CacheConfig(
+            cacheDurationInSeconds = cacheDurationInSeconds,
+            cacheAttributes = cacheAttributes
+        )
     }
 
     private fun startRoktEventListener(flow: Flow<RoktEvent>, viewName: String? = null) {

--- a/Rokt.Widget/ios/RNRoktWidget.m
+++ b/Rokt.Widget/ios/RNRoktWidget.m
@@ -109,7 +109,7 @@ RCT_EXPORT_METHOD(executeWithConfig:(NSString *)viewName
     
     NSMutableDictionary *nativePlaceholders = [[NSMutableDictionary alloc]initWithCapacity:placeholders.count];
 
-    NSMutableDictionary *configMap = [self convertToMutableDictionaryOfStrings:roktConfig];
+    NSMutableDictionary *configMap = [roktConfig mutableCopy];
 
     RoktConfig *config = [self buildRoktConfig:configMap];
 
@@ -304,11 +304,20 @@ RCT_EXPORT_METHOD(setFulfillmentAttributes:(NSDictionary *)attributes) {
 - (RoktConfig*)buildRoktConfig:(NSDictionary*)config
 {
     Builder *builder = [[Builder alloc] init];
-    NSString *colorMode = config[@"colorMode"];
+    NSMutableDictionary *configMap = [self convertToMutableDictionaryOfStrings:config];
+    NSString *colorMode = configMap[@"colorMode"];
+    NSMutableDictionary *cacheConfig = config[@"cacheConfig"];
     
     if (colorMode != nil) {
         ColorMode value = [self stringToColorMode:colorMode];
         [builder colorMode:value];
+    }
+    if (cacheConfig != nil) {
+        NSDictionary *cacheAttributes = cacheConfig[@"cacheAttributes"];
+        NSNumber *duration = cacheConfig[@"cacheDurationInSeconds"];
+        NSTimeInterval cacheDurationInSeconds = duration ? [duration doubleValue] : CacheConfig.maxCacheDuration;
+        CacheConfig *cacheConfig = [[CacheConfig alloc] initWithCacheDuration:cacheDurationInSeconds cacheAttributes:cacheAttributes];
+        [builder cacheConfig:(cacheConfig)];
     }
     return [builder build];
 }

--- a/Rokt.Widget/package-lock.json
+++ b/Rokt.Widget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rokt/react-native-sdk",
-  "version": "4.7.0-alpha.1",
+  "version": "4.7.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rokt/react-native-sdk",
-      "version": "4.7.0-alpha.1",
+      "version": "4.7.0-alpha.2",
       "license": "Copyright 2020 Rokt Pte Ltd",
       "dependencies": {
         "@expo/config-plugins": "^7.2.5"

--- a/Rokt.Widget/package.json
+++ b/Rokt.Widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rokt/react-native-sdk",
-  "version": "4.7.0-alpha.1",
+  "version": "4.7.0-alpha.2",
   "description": "Rokt Mobile SDK to integrate ROKT Api into ReactNative application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/Rokt.Widget/rokt-react-native-sdk.podspec
+++ b/Rokt.Widget/rokt-react-native-sdk.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   
 
   s.dependency "React"
-  s.dependency "Rokt-Widget", "~> 4.7.0-alpha.1"
+  s.dependency "Rokt-Widget", "~> 4.7.0-alpha.3"
 end

--- a/Rokt.Widget/src/Rokt.tsx
+++ b/Rokt.Widget/src/Rokt.tsx
@@ -70,6 +70,21 @@ interface RNRoktWidget {
 
 export interface IRoktConfig {
     readonly colorMode?: ColorMode;
+    readonly cacheConfig?: CacheConfig;
+}
+
+/**
+ * Cache configuration for Rokt SDK
+ */
+export class CacheConfig {
+    /**
+     * @param cacheDurationInSeconds - The duration in seconds for which the Rokt SDK should cache the experience. Default is 90 minutes
+     * @param cacheAttributes - optional attributes to be used as cache key. If null, all the attributes will be used as the cache key
+     */
+  constructor(
+    public readonly cacheDurationInSeconds?: number,
+    public readonly cacheAttributes?: Record<string, string>
+  ) {}
 }
 
 class RoktConfig implements IRoktConfig {
@@ -80,9 +95,14 @@ class RoktConfig implements IRoktConfig {
 
 export class RoktConfigBuilder implements Partial<IRoktConfig> {
     readonly colorMode?: ColorMode;
+    readonly cacheConfig?: CacheConfig;
 
     public withColorMode(value: ColorMode): this & Pick<IRoktConfig, 'colorMode'> {
         return Object.assign(this, {colorMode: value})
+    }
+
+    public withCacheConfig(value: CacheConfig): this & Pick<IRoktConfig, 'cacheConfig'> {
+        return Object.assign(this, {cacheConfig: value})
     }
 
     public build(this: IRoktConfig) {

--- a/Rokt.Widget/src/index.tsx
+++ b/Rokt.Widget/src/index.tsx
@@ -1,9 +1,9 @@
 import 'react-native'
 import { NativeModules } from 'react-native';
 import { RoktEmbeddedView } from './rokt-embedded-view'
-import { Rokt, IRoktConfig, RoktConfigBuilder, ColorMode } from './Rokt'
+import { Rokt, IRoktConfig, RoktConfigBuilder, ColorMode, CacheConfig } from './Rokt'
 
 const { RoktEventManager } = NativeModules;
 
-export {RoktEmbeddedView, Rokt, RoktEventManager, RoktConfigBuilder};
-export type {IRoktConfig, ColorMode};
+export { RoktEmbeddedView, Rokt, RoktEventManager, RoktConfigBuilder, CacheConfig };
+export type { IRoktConfig, ColorMode };

--- a/RoktSampleApp/ios/Podfile.lock
+++ b/RoktSampleApp/ios/Podfile.lock
@@ -351,13 +351,13 @@ PODS:
     - React-jsi (= 0.69.12)
     - React-logger (= 0.69.12)
     - React-perflogger (= 0.69.12)
-  - RNCCheckbox (0.5.16):
+  - RNCCheckbox (0.5.17):
     - BEMCheckBox (~> 1.4)
     - React-Core
-  - rokt-react-native-sdk (4.7.0-alpha.1):
+  - rokt-react-native-sdk (4.7.0-alpha.2):
     - React
-    - Rokt-Widget (~> 4.7.0-alpha.1)
-  - Rokt-Widget (4.7.0-alpha.1)
+    - Rokt-Widget (~> 4.7.0-alpha.3)
+  - Rokt-Widget (4.7.0-alpha.3)
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -558,9 +558,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: c9cd9f21bbcb3b9c6deedbb66f13e373f57dd795
   React-runtimeexecutor: ea78653fbc68bd6f2d3f5e7e311bc5a9dc8bfeca
   ReactCommon: f4bb9e5209ea5c3c6ab25e100895119e58d6e50a
-  RNCCheckbox: 75255b03e604bbcc26411eb31c4cbe3e3865f538
-  rokt-react-native-sdk: 81799fbf43ce1d34e4e9fdd92dbdfa692d71ef93
-  Rokt-Widget: e7cc3037d07569af2e74b556e68e6272494367a7
+  RNCCheckbox: a3ca9978cb0846b981d28da4e9914bd437403d77
+  rokt-react-native-sdk: 84a626797c22fe3a72a554392836b09076f2ad3e
+  Rokt-Widget: 4d7639bdfb046cd128a721f0a7a0b1caf65e61ca
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8a90b50af67eaa9fe94fd03e550bfeab06096873
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/RoktSampleApp/package.json
+++ b/RoktSampleApp/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@react-native-community/checkbox": "^0.5.12",
-    "@rokt/react-native-sdk": "file:../Rokt.Widget/rokt-react-native-sdk-4.7.0-alpha.1.tgz",
+    "@rokt/react-native-sdk": "file:../Rokt.Widget/rokt-react-native-sdk-4.7.0-alpha.2.tgz",
     "crypto-js": "^4.0.0",
     "node-forge": "^1.3.1",
     "react": "18.0.0",


### PR DESCRIPTION
### Background ###

* Add cache config support in ReactNative javascript layer.
* Change the native wrapper for Android and iOS to accept `cacheConfig` param from JS bridge.
* Pass cacheConfig to the native SDK(TODO: iOS)

Fixes [LAYOUT-1641](https://rokt.atlassian.net/browse/LAYOUT-1641)

### What Has Changed: ###

Cache API support in ReactNative SDK

### How Has This Been Tested? ###

Tested locally

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.