### PR TITLE
fix: changes required to support RN 0.80.0

### DIFF
--- a/Rokt.Widget/android/build.gradle
+++ b/Rokt.Widget/android/build.gradle
@@ -13,9 +13,8 @@ buildscript {
 }
 
 def isNewArchitectureEnabled() {
-    // The new architecture is not yet public
-    // We can only use the new architecture in build time, not runtime
-    return project.hasProperty("newArchEnabled") ? project.newArchEnabled.toBoolean() : false
+    // React Native 0.80+ uses this standard detection approach
+    return project.hasProperty("newArchEnabled") && project.newArchEnabled.toBoolean()
 }
 
 apply plugin: 'com.android.library'

--- a/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetPackage.kt
+++ b/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetPackage.kt
@@ -1,6 +1,7 @@
 package com.rokt.reactnativesdk
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
+import com.facebook.react.bridge.ModuleSpec
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
@@ -17,7 +18,7 @@ import java.util.*
  *
  * You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
  */
-class RNRoktWidgetPackage : TurboReactPackage() {
+class RNRoktWidgetPackage : BaseReactPackage() {
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
         listOf(RNRoktWidgetModule(reactContext))
 
@@ -31,6 +32,7 @@ class RNRoktWidgetPackage : TurboReactPackage() {
             null
         }
     }
+
     override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
         return ReactModuleInfoProvider {
             val moduleInfos: MutableMap<String, ReactModuleInfo> =
@@ -40,13 +42,17 @@ class RNRoktWidgetPackage : TurboReactPackage() {
                 ReactModuleInfo(
                     RNRoktWidgetModuleImpl.REACT_CLASS,
                     RNRoktWidgetModuleImpl.REACT_CLASS,
-                    _canOverrideExistingModule = false,  // canOverrideExistingModule
-                    _needsEagerInit = false,  // needsEagerInit
-                    isCxxModule = false,  // isCxxModule
-                    isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED // isTurboModule
+                     false,  // canOverrideExistingModule
+                     false,  // needsEagerInit
+                     false,  // isCxxModule
+                     BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, // isTurboModule
                 )
             )
             moduleInfos.toMap()
         }
     }
+
+    override fun getViewManagers(reactContext: ReactApplicationContext): List<ModuleSpec> = listOf(
+        ModuleSpec.viewManagerSpec { RoktEmbeddedViewManager() }
+    )
 }

--- a/Rokt.Widget/android/src/newarch/java/com/rokt/reactnativesdk/RoktEmbeddedViewManager.kt
+++ b/Rokt.Widget/android/src/newarch/java/com/rokt/reactnativesdk/RoktEmbeddedViewManager.kt
@@ -6,9 +6,6 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RoktNativeWidgetManagerInterface
 import com.rokt.roktsdk.Widget
 
-// @ReactModule annotation may be unnecessary if registration is handled by codegen/package
-// but keeping it commented in case it's needed
-// @ReactModule(name = RoktEmbeddedViewManagerImpl.REACT_CLASS)
 class RoktEmbeddedViewManager : SimpleViewManager<Widget>(), RoktNativeWidgetManagerInterface<Widget> {
 
     private val impl = RoktEmbeddedViewManagerImpl()

--- a/RoktSampleApp/android/app/src/main/java/com/roktsampleapp/MainApplication.kt
+++ b/RoktSampleApp/android/app/src/main/java/com/roktsampleapp/MainApplication.kt
@@ -11,7 +11,6 @@ import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
-import com.rokt.reactnativesdk.RoktEmbeddedViewPackage;
 
 class MainApplication : Application(), ReactApplication {
 
@@ -20,7 +19,7 @@ class MainApplication : Application(), ReactApplication {
         override fun getPackages(): List<ReactPackage> =
             PackageList(this).packages.apply {
               // Packages that cannot be autolinked yet can be added manually here, for example:
-              add(RoktEmbeddedViewPackage())
+              // add(MyReactNativePackage())
             }
 
         override fun getJSMainModuleName(): String = "index"


### PR DESCRIPTION
### Background ###

Changes required for ReactNative Android 0.80.0 version

### What Has Changed: ###

- Register View Manager in `RNRoktWidgetPackage`
- Remove manual registration of `RoktEmbeddedViewPackage`
- Replace deprecated `TurboReactPackage` with `BaseReactPackage`

### How Has This Been Tested? ###

Tested locally with both RN new and old architectures.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.