### PR TITLE
fix: Update podspec and Gradle build for backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- New Architecture support
+- Real time events
+- Support new response action type `ExternalPaymentTrigger`
+- Sessions are now retained between app restarts

--- a/Rokt.Widget/android/build.gradle
+++ b/Rokt.Widget/android/build.gradle
@@ -17,6 +17,19 @@ def isNewArchitectureEnabled() {
     return project.hasProperty("newArchEnabled") && project.newArchEnabled.toBoolean()
 }
 
+def supportsNamespace() {
+    def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+    def major = parsed[0].toInteger()
+    def minor = parsed[1].toInteger()
+
+    // Namespace support was added in 7.3.0
+    if (major == 7 && minor >= 3) {
+        return true
+    }
+
+    return major >= 8
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 if (isNewArchitectureEnabled()) {
@@ -37,10 +50,17 @@ android {
     lintOptions {
         abortOnError false
     }
-    buildFeatures {
-        buildConfig = true
+    if (supportsNamespace()) {
+        namespace 'com.rokt.reactnativesdk'
+        buildFeatures {
+            buildConfig = true
+        }
+        sourceSets {
+            main {
+                manifest.srcFile "src/main/AndroidManifestNew.xml"
+            }
+        }
     }
-    namespace 'com.rokt.reactnativesdk'
     sourceSets {
         main {
             if (isNewArchitectureEnabled()) {

--- a/Rokt.Widget/android/src/main/AndroidManifest.xml
+++ b/Rokt.Widget/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.rokt.reactnativesdk">
 </manifest>
-  

--- a/Rokt.Widget/android/src/main/AndroidManifestNew.xml
+++ b/Rokt.Widget/android/src/main/AndroidManifestNew.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetPackage.kt
+++ b/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RNRoktWidgetPackage.kt
@@ -1,6 +1,6 @@
 package com.rokt.reactnativesdk
 
-import com.facebook.react.BaseReactPackage
+import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.ModuleSpec
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
@@ -18,7 +18,7 @@ import java.util.*
  *
  * You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
  */
-class RNRoktWidgetPackage : BaseReactPackage() {
+class RNRoktWidgetPackage : TurboReactPackage() {
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
         listOf(RNRoktWidgetModule(reactContext))
 
@@ -39,6 +39,7 @@ class RNRoktWidgetPackage : BaseReactPackage() {
                 RNRoktWidgetModuleImpl.REACT_CLASS,
                 false, // canOverrideExistingModule
                 false, // needsEagerInit
+                true, // hasConstants
                 false, // isCxxModule
                 BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, // isTurboModule
             ),

--- a/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RoktEmbeddedViewPackage.kt
+++ b/Rokt.Widget/android/src/main/java/com/rokt/reactnativesdk/RoktEmbeddedViewPackage.kt
@@ -1,6 +1,6 @@
 package com.rokt.reactnativesdk
 
-import com.facebook.react.BaseReactPackage
+import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
@@ -17,7 +17,7 @@ import com.facebook.react.uimanager.ViewManager
  *
  * You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
  */
-class RoktEmbeddedViewPackage : BaseReactPackage() {
+class RoktEmbeddedViewPackage : TurboReactPackage() {
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
         listOf(RoktEmbeddedViewManager())
 
@@ -36,6 +36,7 @@ class RoktEmbeddedViewPackage : BaseReactPackage() {
                     RoktEmbeddedViewManagerImpl.REACT_CLASS,
                     false, // canOverrideExistingModule
                     false, // needsEagerInit
+                    true, // hasConstants
                     false, // isCxxModule
                     BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, // isTurboModule
                 ),

--- a/Rokt.Widget/rokt-react-native-sdk.podspec
+++ b/Rokt.Widget/rokt-react-native-sdk.podspec
@@ -26,18 +26,22 @@ Pod::Spec.new do |s|
     # Manual fallback for older React Native versions
     s.dependency "React-Core"
     s.compiler_flags = folly_compiler_flags
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Public/React-Codegen\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++20"
+
+    # Simplified configuration for older React Native versions
+    s.pod_target_xcconfig = {
+      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
-    s.dependency "React-Codegen"
+
+    # Only include essential dependencies for React Native 0.69.x
     s.dependency "RCT-Folly"
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
 
+    # Only include TurboModule support if New Architecture is enabled
     if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+      s.dependency "ReactCommon/turbomodule/core"
       s.compiler_flags << " -DRCT_NEW_ARCH_ENABLED=1"
     end
   end


### PR DESCRIPTION
### Background ###

Fixes to make the SDK work with ReactNative version 0.69.x

### What Has Changed: ###

Updated gradle and podspec

### How Has This Been Tested? ###

Tested locally

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.