### PR TITLE
fix: SQDSDKS-7481 - Update release workflow to publish tarball instead of direct npm package

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -152,7 +152,13 @@ jobs:
         run: |
           cd Rokt.Widget
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-          npm publish --access=public --tag=latest
+          TARBALL="rokt-react-native-sdk-${{ needs.setup-and-version.outputs.final_version }}.tgz"
+          if [ ! -f "$TARBALL" ]; then
+            echo "Error: Expected tarball $TARBALL not found in Rokt.Widget directory"
+            exit 1
+          fi
+          echo "Publishing tarball: $TARBALL"
+          npm publish "$TARBALL" --access=public --tag=latest
 
       - uses: ffurrer2/extract-release-notes@cae32133495112d23e3569ad04fef240ba4e7bc8 # v2.3.0
         id: extract-release-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix npm publish issue
+
 ## [4.10.0] - 2025-07-04
 
 ### Added


### PR DESCRIPTION
### Background ###

The published npm package was missing dist directory where the compiled code is present

Fixes [SQDSDKS-7481](https://mparticle-eng.atlassian.net/browse/SQDSDKS-7481)

### What Has Changed: ###

- Updated the npm publish command to use the tarball for release.

### How Has This Been Tested? ###

Tested by publishing locally

### Notes

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.