### PR TITLE
fix: harden GitHub Actions workflows and add zizmor CI check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,9 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  checks: write
-  id-token: write
 
 jobs:
   trunk-check:
@@ -18,6 +15,8 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:
@@ -32,6 +31,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -62,6 +63,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download and flatten artifacts
         uses: ./.github/actions/download-and-flatten
@@ -95,6 +98,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download and flatten artifacts
         uses: ./.github/actions/download-and-flatten

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   trunk-check:

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -54,6 +56,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download and flatten artifacts
         uses: ./.github/actions/download-and-flatten
@@ -87,6 +91,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download and flatten artifacts
         uses: ./.github/actions/download-and-flatten
@@ -120,6 +126,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Get current version
         id: version-file
         run: |
@@ -132,6 +140,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download and flatten package artifacts
         uses: ./.github/actions/download-and-flatten

--- a/.github/workflows/trunk-upgrade.yml
+++ b/.github/workflows/trunk-upgrade.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Trunk Check

--- a/.github/workflows/trunk-upgrade.yml
+++ b/.github/workflows/trunk-upgrade.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,12 +18,15 @@ permissions:
 jobs:
   zizmor:
     name: Scan GitHub Actions workflows
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install zizmor
-        run: pip install zizmor
+        run: pip install zizmor==1.23.1
       - name: Run zizmor
         run: zizmor --format plain .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: Zizmor Security Scan
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install zizmor
+        run: pip install zizmor
+      - name: Run zizmor
+        run: zizmor --format plain .

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,7 +19,6 @@ jobs:
   zizmor:
     name: Scan GitHub Actions workflows
     runs-on: ubuntu-24.04
-    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -27,6 +26,7 @@ jobs:
       - name: Install zizmor
         run: pip install zizmor==1.23.1
       - name: Run zizmor
+        continue-on-error: true
         run: zizmor --format plain .
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to checkout steps across all workflows (prevents credential leakage via artifacts)
- Tighten workflow-level permissions on `pull_request.yml` — removed `checks: write` and `id-token: write` from workflow level (already scoped at job level where needed), kept `pull-requests: read`
- Add `zizmor.yml` CI workflow that scans GitHub Actions on every PR touching workflow files:
  - Pinned to zizmor v1.23.1 for reproducibility
  - Pinned to ubuntu-24.04 runner
  - Passes `GH_TOKEN` for richer audits
  - Uses `continue-on-error: true` at the step level so pre-existing findings don't block PRs (job shows green)
- Fix comment spacing on trunk-upgrade.yml checkout action

**Note:** `draft-release-publish.yml` checkout intentionally left without `persist-credentials: false` because `peter-evans/create-pull-request` needs git credentials to push.

## Test plan
- [x] Verify CI/CD pipelines run successfully
- [x] Confirm zizmor workflow runs on this PR

## Rollback plan
Revert this PR.