### PR TITLE
fix: restore pull request workflow token permission

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  id-token: write
 
 jobs:
   trunk-check:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  id-token: write
 
 jobs:
   trunk-check:
@@ -133,6 +132,10 @@ jobs:
       github.event.pull_request.draft == false
     needs: [build-test-ios, build-test-android]
     name: Notify GChat
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
     uses: ROKT/rokt-workflows/.github/workflows/oss_pr_opened_notification.yml@1859338d7c2c2b873233505c751acbf09fb218d5 # main
     secrets:
       gchat_webhook: ${{ secrets.GCHAT_PRS_WEBHOOK }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,14 +3,14 @@ name: Zizmor Security Scan
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
+      - .github/workflows/**
+      - .github/actions/**
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
+      - .github/workflows/**
+      - .github/actions/**
 
 permissions:
   contents: read


### PR DESCRIPTION
## Background

- A recent workflow hardening change removed the PR workflow's `id-token` permission.
- That caused GitHub Actions to reject the reusable PR notification workflow during validation because it requests `id-token: write`.
- This change restores the required permission so pull request workflows can run again.

## What Has Changed

- Restored `id-token: write` at the workflow level in `.github/workflows/pull_request.yml`.
- Removed redundant quotes from `.github/workflows/zizmor.yml` path globs so `trunk check --ci` passes cleanly for this branch.

## Screenshots/Video

- N/A — no visual changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.
