### PR TITLE
Add --allow-same-version to draft release workflow

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -54,12 +54,12 @@ jobs:
       - name: Update package.json version
         working-directory: Rokt.Widget
         run: |
-          npm version ${{ steps.bump-version.outputs.new_version }} --no-git-tag-version
+          npm version ${{ steps.bump-version.outputs.new_version }} --no-git-tag-version --allow-same-version
 
       - name: Update sample apps package.json versions
         run: |
-          npm version ${{ steps.bump-version.outputs.new_version }} --no-git-tag-version --prefix RoktSampleApp
-          npm version ${{ steps.bump-version.outputs.new_version }} --no-git-tag-version --prefix ExpoTestApp
+          npm version ${{ steps.bump-version.outputs.new_version }} --no-git-tag-version --allow-same-version --prefix RoktSampleApp
+          npm version ${{ steps.bump-version.outputs.new_version }} --no-git-tag-version --allow-same-version --prefix ExpoTestApp
           # Update the @rokt/react-native-sdk dependency version
           sed -i "s|rokt-react-native-sdk-[0-9]\+\.[0-9]\+\.[0-9]\+\.tgz|rokt-react-native-sdk-${{ steps.bump-version.outputs.new_version }}.tgz|g" RoktSampleApp/package.json ExpoTestApp/package.json
 


### PR DESCRIPTION
## Summary
- Adds `--allow-same-version` flag to all three `npm version` commands in `draft-release-publish.yml`
- Fixes the workflow failure when `Rokt.Widget/package.json` version already matches the bumped version (e.g. VERSION file at `4.12.2` bumped to `5.0.0`, but package.json already at `5.0.0`)
- Ref: https://github.com/ROKT/rokt-sdk-react-native/actions/runs/24518050892/job/71667633543#step:8:7

## Test plan
- [ ] Re-run the publish-draft-release workflow with `major` bump type and confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)