### PR TITLE
chore: bump native Android SDK to 4.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+
+- Updated Rokt native Android SDK to 4.14.5.
+
 ## [4.12.2] - 2026-03-05
 
 ### Updated

--- a/Rokt.Widget/android/build.gradle
+++ b/Rokt.Widget/android/build.gradle
@@ -101,5 +101,5 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
-    implementation ('com.rokt:roktsdk:4.14.0')
+    implementation ('com.rokt:roktsdk:4.14.5')
 }

--- a/Rokt.Widget/rokt-react-native-sdk.podspec
+++ b/Rokt.Widget/rokt-react-native-sdk.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
   if respond_to?(:spm_dependency, true)
     spm_dependency(s,
       url: 'https://github.com/ROKT/rokt-sdk-ios.git',
-      requirement: { kind: 'upToNextMajorVersion', minimumVersion: '4.15.0' },
+      requirement: { kind: 'upToNextMinorVersion', minimumVersion: '4.15.0' },
       products: ['Rokt-Widget']
     )
   end

--- a/Rokt.Widget/rokt-react-native-sdk.podspec
+++ b/Rokt.Widget/rokt-react-native-sdk.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
   if respond_to?(:spm_dependency, true)
     spm_dependency(s,
       url: 'https://github.com/ROKT/rokt-sdk-ios.git',
-      requirement: { kind: 'upToNextMinorVersion', minimumVersion: '4.15.0' },
+      requirement: { kind: 'upToNextMajorVersion', minimumVersion: '4.15.0' },
       products: ['Rokt-Widget']
     )
   end


### PR DESCRIPTION
## Background

- Bumps the native Android SDK dependency used by the React Native SDK on the v4 maintenance line from `4.14.0` to `4.14.5`.
- This is the React Native counterpart to the Android v4 maintenance work: the RN package pins `com.rokt:roktsdk` in `Rokt.Widget/android/build.gradle`, so RN consumers only pick up a new Android SDK version when this pin is bumped and a new RN package is published.

## What Has Changed

- `Rokt.Widget/android/build.gradle`: `com.rokt:roktsdk` `4.14.0` → `4.14.5`.
- `CHANGELOG.md`: added an `Unreleased > Updated` entry.

## CI status — failing `Build & Test iOS` is unrelated to this change

The `Build & Test iOS` check is failing for a reason **unrelated to this Android-only change**, and a fix has already been opened in the iOS SDK repo.

- **Symptom:** SwiftPM dependency resolution fails under Xcode 16.4:
  ```
  /Package.swift:8:23: error: 'v15' is unavailable
  note: 'v15' was introduced in PackageDescription 5.5
  xcodebuild: error: Could not resolve package dependencies (exit code 74)
  ```
- **Root cause:** This repo resolves `Rokt-Widget` from `rokt-sdk-ios` via the SPM bridge (range `>= 4.15.0, < 5.0.0`). SPM picks the highest 4.x tag, `4.16.5`, whose `Package.swift` declares `// swift-tools-version:5.3` but uses `.iOS(.v15)` — and `.v15` requires PackageDescription 5.5+, so the manifest is invalid. (Last good tag: `4.16.4`, which used `.iOS(.v12)`.)
- **Action taken:** Root-cause fix opened in the iOS SDK repo → **ROKT/rokt-sdk-ios#207** (`fix(spm): raise swift-tools-version to 5.5`). Once that lands and a patched tag (e.g. `4.16.6`) is released, this check passes automatically on a re-run — no change required in this PR (no committed `Package.resolved`, so SPM re-resolves to the fixed version).
- **Scope:** Intentionally not addressed here, since it is an iOS-package issue independent of the Android dependency bump. All other checks (Android build/test, packaging, Trunk, security, mergeability) are green.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- Targets the newly created `maintenance/4.x` branch (cut from the `4.12.2` tag).
