### PR TITLE
ci(release): support maintenance-branch releases without clobbering latest

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - maintenance/*
     paths:
       - VERSION
 
@@ -163,6 +164,8 @@ jobs:
 
       - name: Publish to npm with OIDC
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           cd Rokt.Widget
           TARBALL="rokt-react-native-sdk-${{ needs.setup-and-version.outputs.final_version }}.tgz"
@@ -170,8 +173,16 @@ jobs:
             echo "Error: Expected tarball $TARBALL not found in Rokt.Widget directory"
             exit 1
           fi
-          echo "Publishing tarball: $TARBALL"
-          npm publish "$TARBALL" --access=public --tag=latest
+          # Releases from main own the npm "latest" dist-tag. Maintenance branches
+          # publish under a branch-derived tag (e.g. maintenance/4.x -> 4.x) so a
+          # patch on an older major never moves "latest" away from the current line.
+          if [ "$REF_NAME" = "main" ]; then
+            NPM_TAG="latest"
+          else
+            NPM_TAG="${REF_NAME#maintenance/}"
+          fi
+          echo "Publishing tarball: $TARBALL with dist-tag: $NPM_TAG"
+          npm publish "$TARBALL" --access=public --tag="$NPM_TAG"
 
       - uses: ffurrer2/extract-release-notes@273da39a24fb7db106a35526c8162815faffd31d # v3.1.0
         id: extract-release-notes
@@ -189,7 +200,7 @@ jobs:
       - name: Create Github release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          makeLatest: true
+          makeLatest: ${{ github.ref_name == 'main' }}
           tag: ${{ needs.setup-and-version.outputs.final_version }}
           artifacts: Rokt.Widget/*.tgz
           body: |


### PR DESCRIPTION
## Why

I will not run a release until CI can correctly publish from a maintenance branch. Today it can't, and `origin/maintenance/4.x` already exists while `main` is on `5.0.1`.

[release-publish.yml](.github/workflows/release-publish.yml) only triggered on `main` and hardcoded both the npm `latest` dist-tag and the GitHub release "Latest" marker. So:

- Merging a `4.x` release PR **never publishes** — the workflow doesn't fire on maintenance branches.
- If it did fire, `npm publish --tag=latest` would move npm's `latest` tag from `5.x` back to `4.x`, **silently downgrading every `npm install`**, and the GitHub release would be marked "Latest", demoting the current line.

This aligns the React Native publish flow with the iOS SDK's existing maintenance-branch behavior.

## What changed

All in [release-publish.yml](.github/workflows/release-publish.yml):

1. **Trigger** — publish now fires on `maintenance/*` as well as `main`.
2. **npm dist-tag** — derived from the branch: `main` → `latest`, `maintenance/4.x` → `4.x`. A patch on an older major never moves `latest`.
3. **GitHub release "Latest"** — `makeLatest` is now `true` only on `main`.

The build/test matrix (iOS, Android, package) is branch-agnostic and unchanged. The draft workflow already supports maintenance branches (`base: github.ref_name`).

## Release behavior after this change

| Source branch | npm dist-tag | GitHub "Latest" |
|---|---|---|
| `main` | `latest` | yes |
| `maintenance/4.x` | `4.x` | no |

Consumers wanting the 4.x line install with `npm install @rokt/react-native-sdk@4.x`.

## Validation

- Trunk check passed on push (pre-push hook, no issues).
- Logic verified against iOS [release-publish.yml](https://github.com/ROKT/rokt-sdk-ios/blob/main/.github/workflows/release-publish.yml) (`make_latest: github.ref_name == 'main'`, `maintenance/*` trigger).

## Risk

Low. No effect on the existing `main` release path — `main` still resolves to `--tag=latest` and `makeLatest: true`. New behavior only activates on `maintenance/*` pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)