### PR TITLE
chore: bump native Android SDK to 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+
+- Updated Rokt native Android SDK to 5.1.1.
+
 ## [5.0.1] - 2026-06-05
 
 ### Fixed

--- a/Rokt.Widget/android/build.gradle
+++ b/Rokt.Widget/android/build.gradle
@@ -101,5 +101,5 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
-    implementation ('com.rokt:roktsdk:5.1.0')
+    implementation ('com.rokt:roktsdk:5.1.1')
 }


### PR DESCRIPTION
## Background

- Bumps the native Android SDK dependency used by the React Native SDK from `5.1.0` to `5.1.1`.
- The RN package pins `com.rokt:roktsdk` in `Rokt.Widget/android/build.gradle`, so RN consumers only pick up a new Android SDK version when this pin is bumped and a new RN package is published.

## What Has Changed

- `Rokt.Widget/android/build.gradle`: `com.rokt:roktsdk` `5.1.0` → `5.1.1`.
- `CHANGELOG.md`: added an `Unreleased > Updated` entry.

## Note

- The Android SDK `5.1.1` release has not been published to Maven yet. The `Build & Test Android` check will fail until `com.rokt:roktsdk:5.1.1` is available on Maven Central, after which a re-run will pass with no further changes to this PR.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.
