### PR TITLE
fix: embedded view collapsing to zero height in a column container

### DIFF
--- a/Rokt.Widget/src/rokt-embedded-view.android.tsx
+++ b/Rokt.Widget/src/rokt-embedded-view.android.tsx
@@ -53,7 +53,13 @@ interface MarginChangedEvent {
 
 const styles = StyleSheet.create({
   widget: {
-    flex: 1,
+    // Do NOT use `flex: 1` here. It expands to `flexBasis: 0%`, which takes
+    // precedence over `height` on the parent's main axis, so inside any
+    // auto-height column parent the widget collapses to 0 and the placement is
+    // never visible even though the SDK selected it and reported its height.
+    // `alignSelf: "stretch"` gives the full available width without touching the
+    // main axis, leaving the measured `height` free to apply.
+    alignSelf: "stretch",
     backgroundColor: "transparent",
   },
 });

--- a/Rokt.Widget/src/rokt-embedded-view.ios.tsx
+++ b/Rokt.Widget/src/rokt-embedded-view.ios.tsx
@@ -121,7 +121,13 @@ export class RoktEmbeddedView extends Component<
 
 const styles = StyleSheet.create({
   widget: {
-    flex: 1,
+    // Do NOT use `flex: 1` here. It expands to `flexBasis: 0%`, which takes
+    // precedence over `height` on the parent's main axis, so inside any
+    // auto-height column parent the widget collapses to 0 and the placement is
+    // never visible even though the SDK selected it and reported its height.
+    // `alignSelf: "stretch"` gives the full available width without touching the
+    // main axis, leaving the measured `height` free to apply.
+    alignSelf: "stretch",
     backgroundColor: "transparent",
     overflow: "hidden",
   },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- `RoktEmbeddedView` styles its own native view with `flex: 1` alongside the height it receives from the native SDK:

  ```js
  style={[styles.widget, { height: this.state.height }]}
  ```

- In Yoga, `flex: 1` expands to `flexGrow: 1, flexShrink: 1, flexBasis: 0%`, and `flexBasis` takes precedence over `height` on the parent's **main** axis. Whenever the view is rendered inside an auto-height **column** container, the base size resolves to `0`, `flexGrow` has no free space to distribute, and the view stays 0pt tall.
- The result is a silent failure that looks like a selection or targeting problem: the placement is selected, `PlacementReady` and `PlacementInteractive` fire, the native SDK reports the measured height to JS, and nothing is ever visible — so no impression or view signal follows.
- This is easy to miss because it depends entirely on the immediate parent. It works when the parent does not constrain the main axis, for example as a direct child of a `ScrollView` as in `RoktSampleApp`, which is the arrangement used in our sample app and docs. Wrapping the component in a plain `<View>` — a very common integration pattern — is enough to trigger it.

## What Has Changed

- Replaced `flex: 1` with `alignSelf: "stretch"` in `styles.widget` in both `rokt-embedded-view.ios.tsx` and `rokt-embedded-view.android.tsx`.
- `alignSelf: "stretch"` still gives the widget the full available width in a column layout, but leaves the main axis untouched so the measured `height` applies.
- Added a comment on both platforms explaining why `flex: 1` must not be reintroduced.
- No public API change. No change to the height/margin event plumbing.

## Screenshots/Video

Reproduced with a minimal app that renders `<RoktEmbeddedView>` inside `<View style={{ marginBottom: 24 }}>` (an auto-height column parent), on iOS 26.4 simulator, React Native 0.81.5, New Architecture enabled.

**Before** — placement selected and height reported, container never grows:

```
selectPlacements(...) placeholders={"RoktEmbedded1":74}
RoktEvents: PlacementReady
RoktEvents: PlacementInteractive
WidgetHeightChanges: RoktEmbedded1 height=186
WidgetHeightChanges: RoktEmbedded1 height=470.67
WidgetHeightChanges: RoktEmbedded1 height=530.33
container onLayout height=0        <-- never grows, nothing rendered
```

**After** — same app, same parent, no consumer-side change: the layout renders at its
reported height.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- **Tests:** the package has no JS test harness (`Rokt.Widget/package.json` → `"test": "echo \"Error: no test specified\""`), so there is nowhere to land a unit test for this. A layout regression test needs a renderer assertion on the resolved height, which would mean introducing `jest` + `react-test-renderer` to the package. Happy to do that as a follow-up if we want it.
- **Docs:** no doc change needed — the README example does not set a wrapper style, and it now works in any container.
- **Verified on:** stock `flex: 1` fails and the patched style renders, on both `4.11.2` and `4.12.2`, inline and inside a `Modal`. Behaviour as a direct `ScrollView` child is unchanged.
- **Android caveat unrelated to this PR:** on RN 0.83+ with the New Architecture, versions before `5.0.1` never deliver the height to JS at all (fixed in #272). This change is necessary but not sufficient on those older versions.
- The same `flex: 1` pattern exists in `mParticle/react-native-mparticle` (`js/rokt/rokt-layout-view.{ios,android}.tsx`), which ports this component as `RoktLayoutView`. Worth porting this fix there too.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- No ticket — found while investigating an embedded placement that selected successfully but never rendered.
