### PR TITLE
fix(android): configure embedded views on New Architecture

### DIFF
--- a/Rokt.Widget/android/src/newarch/java/com/rokt/reactnativesdk/RoktEmbeddedViewManager.kt
+++ b/Rokt.Widget/android/src/newarch/java/com/rokt/reactnativesdk/RoktEmbeddedViewManager.kt
@@ -2,7 +2,8 @@ package com.rokt.reactnativesdk
 
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RoktNativeWidgetManagerDelegate
 import com.facebook.react.viewmanagers.RoktNativeWidgetManagerInterface
 import com.rokt.roktsdk.Widget
 
@@ -10,6 +11,12 @@ class RoktEmbeddedViewManager :
     SimpleViewManager<Widget>(),
     RoktNativeWidgetManagerInterface<Widget> {
     private val impl = RoktEmbeddedViewManagerImpl()
+
+    // Fabric routes props through the codegen-generated delegate; without this override the
+    // base ViewManager logs "ViewManager using codegen must override getDelegate method".
+    private val delegate = RoktNativeWidgetManagerDelegate<Widget, RoktEmbeddedViewManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<Widget> = delegate
 
     override fun getName(): String = impl.getName()
 
@@ -22,7 +29,6 @@ class RoktEmbeddedViewManager :
             mapOf("registrationName" to RoktEmbeddedViewManagerImpl.EVENT_MARGIN_CHANGED),
     )
 
-    @ReactProp(name = "placeholderName")
     override fun setPlaceholderName(view: Widget?, value: String?) {
         impl.setPlaceholderName(view, value)
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- On React Native's New Architecture, `RoktEmbeddedViewManager` implements the codegen-generated interface but did not return its generated delegate from `getDelegate()`.
- React Native therefore logged a `ReactNoCrashSoftException` whenever it created `RoktNativeWidget`, and `placeholderName` was not routed through codegen property dispatch.

## What Has Changed

- Instantiated `RoktNativeWidgetManagerDelegate` in the New Architecture view manager and returned it from `getDelegate()`.
- Removed the redundant `@ReactProp` annotation because the generated delegate now owns `placeholderName` dispatch.
- Kept the Paper implementation, event handling, and public JavaScript API unchanged.

## Screenshots/Video

- N/A — no visual changes. Verified by launching the RN 0.81.5 sample under Fabric and confirming the `RoktNativeWidget` delegate soft exception no longer appears in logcat.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- `trunk check --ci`, Widget lint, TypeScript build, Expo plugin build, package creation, and the Android New Architecture build all pass.
- The sample repository has no matching Jest tests or dedicated Android view-manager test harness, so this regression is covered by codegen compilation and emulator runtime validation.
- No documentation or changelog update is required because the public API and integration steps are unchanged.
